### PR TITLE
fix: stabilize tests after DB-first merge

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -757,31 +757,50 @@ class TestResolveContext:
         assert "UK" in ctx.marketplaces
 
 
+@pytest.fixture
+def db_in_cwd(tmp_path, monkeypatch):
+    """Redirect the default DB path (``output/amz_scout.db``, relative to cwd)
+    to a fresh temp DB seeded with a Slate 7 product.
+
+    ``_resolve_context(None)`` resolves the DB via cwd, so this isolates the
+    project=None query tests from the real production DB.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "output").mkdir()
+    db_path = tmp_path / "output" / "amz_scout.db"
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        init_schema(conn)
+        pid, _ = register_product(conn, "Router", "GL.iNet", "GL-Slate 7 (GL-BE3600)")
+        register_asin(conn, pid, "UK", "B0F2MR53D6")
+    return db_path
+
+
 class TestQueryWithoutProject:
     """Test that query functions work with project=None (DB-backed)."""
 
-    def test_query_latest_without_project(self):
+    def test_query_latest_without_project(self, db_in_cwd):
         r = query_latest()
         assert r["ok"] is True
 
-    def test_query_trends_without_project(self):
+    def test_query_trends_without_project(self, db_in_cwd):
         """query_trends with project=None should work if product is in DB."""
         r = query_trends(product="Slate 7", marketplace="UK", auto_fetch=False)
         assert r["ok"] is True
 
-    def test_query_compare_without_project(self):
+    def test_query_compare_without_project(self, db_in_cwd):
         r = query_compare(product="Slate 7")
         assert r["ok"] is True
 
-    def test_query_ranking_without_project(self):
+    def test_query_ranking_without_project(self, db_in_cwd):
         r = query_ranking(marketplace="UK")
         assert r["ok"] is True
 
-    def test_query_availability_without_project(self):
+    def test_query_availability_without_project(self, db_in_cwd):
         r = query_availability()
         assert r["ok"] is True
 
-    def test_query_deals_without_project(self):
+    def test_query_deals_without_project(self, db_in_cwd):
         r = query_deals(marketplace="UK", auto_fetch=False)
         assert r["ok"] is True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+import yaml
 
 from amz_scout.config import (
     MarketplaceConfig,
@@ -12,6 +13,35 @@ from amz_scout.config import (
 )
 
 CONFIG_DIR = Path(__file__).parent.parent / "config"
+
+SAMPLE_PROJECT_YAML = {
+    "project": {"name": "SampleProject", "description": "Fixture for config loader tests"},
+    "target_marketplaces": ["UK", "DE", "CA"],
+    "products": [
+        {
+            "category": "Router",
+            "brand": "ASUS",
+            "model": "RT-BE58",
+            "default_asin": "B0FGDRP3VZ",
+            "marketplace_overrides": {"CA": {"asin": "B0FSPQSJGF"}},
+        },
+        {
+            "category": "Router",
+            "brand": "GL.iNet",
+            "model": "GL-Slate 7 (GL-BE3600)",
+            "default_asin": "B0F2MR53D6",
+        },
+    ],
+}
+
+
+@pytest.fixture
+def sample_project_path(tmp_path):
+    """Write SAMPLE_PROJECT_YAML to a temp file and return its path."""
+    path = tmp_path / "sample_project.yaml"
+    with open(path, "w") as f:
+        yaml.dump(SAMPLE_PROJECT_YAML, f)
+    return path
 
 
 class TestMarketplaceConfig:
@@ -33,33 +63,33 @@ class TestMarketplaceConfig:
 
 
 class TestProjectConfig:
-    def test_load(self):
-        proj = load_project_config(CONFIG_DIR / "BE10000.yaml")
-        assert proj.project.name == "BE10000"
-        assert len(proj.products) == 17
-        assert proj.target_marketplaces == ["UK", "DE", "FR", "IT", "ES", "NL", "CA", "AU"]
+    def test_load(self, sample_project_path):
+        proj = load_project_config(sample_project_path)
+        assert proj.project.name == "SampleProject"
+        assert len(proj.products) == 2
+        assert proj.target_marketplaces == ["UK", "DE", "CA"]
 
-    def test_products_have_asins(self):
-        proj = load_project_config(CONFIG_DIR / "BE10000.yaml")
+    def test_products_have_asins(self, sample_project_path):
+        proj = load_project_config(sample_project_path)
         for p in proj.products:
             assert len(p.default_asin) == 10, f"{p.model} has invalid ASIN"
 
-    def test_to_product(self):
-        proj = load_project_config(CONFIG_DIR / "BE10000.yaml")
+    def test_to_product(self, sample_project_path):
+        proj = load_project_config(sample_project_path)
         product = proj.products[0].to_product()
         assert product.brand == "ASUS"
         assert product.asin_for("CA") == "B0FSPQSJGF"
 
 
 class TestValidation:
-    def test_valid_config(self):
-        proj = load_project_config(CONFIG_DIR / "BE10000.yaml")
+    def test_valid_config(self, sample_project_path):
+        proj = load_project_config(sample_project_path)
         mp = load_marketplace_config(CONFIG_DIR / "marketplaces.yaml")
         errors = validate_config(proj, mp)
         assert errors == []
 
-    def test_invalid_marketplace(self):
-        proj = load_project_config(CONFIG_DIR / "BE10000.yaml")
+    def test_invalid_marketplace(self, sample_project_path):
+        proj = load_project_config(sample_project_path)
         mp = load_marketplace_config(CONFIG_DIR / "marketplaces.yaml")
         proj = proj.model_copy(update={"target_marketplaces": ["UK", "KR"]})
         errors = validate_config(proj, mp)


### PR DESCRIPTION
## Summary

Fixes 6 pre-existing test failures that were merged as part of PR #1 (`9b18b5d`). These tests were failing silently on the feature branch because no CI was running `pytest` — the test plan checkboxes in PR #1 had never been ticked.

- **TestQueryWithoutProject (test_api.py)**: The entire class was hitting the real production DB via \`resolve_db_path()\`'s cwd-relative path. 5 tests "passed" coincidentally because they don't assert on data content; 1 (\`test_query_trends_without_project\`) failed because \`_resolve_asin\` raises when no "Slate 7" product is registered in the prod DB. Fix: new \`db_in_cwd\` fixture that \`monkeypatch.chdir\`s to a temp dir, creates a fresh schema-initialized SQLite DB at \`output/amz_scout.db\`, and seeds a GL-Slate 7 product. All 6 tests in the class now use the fixture for proper isolation.
- **test_config.py (5 tests)**: Tests loaded \`config/BE10000.yaml\`, which was deliberately removed in \`42e47c4\` but the tests were not updated. Fix: replace the file reference with an inline \`SAMPLE_PROJECT_YAML\` constant written to a \`tmp_path\` via a \`sample_project_path\` fixture. Preserves coverage of \`load_project_config\` and \`validate_config\`, which are still exercised via the backward-compat \`--config\` CLI flag.

## Not in scope

3 pre-existing ruff errors in \`tests/test_api.py\` (unused \`json\` / \`pathlib.Path\` imports + the I001 they trigger) are left alone — they're unrelated to this fix and belong in a separate \`chore: fix pre-existing lint\` PR for cleaner history.

## Test plan

- [x] \`pytest -q\` — 220 passed, 0 failed (was 214/6 before)
- [x] \`pytest tests/test_config.py tests/test_api.py::TestQueryWithoutProject -v\` — 17/17 green
- [x] \`ruff check tests/test_api.py tests/test_config.py\` — 0 new issues vs. pre-change baseline