### PR TITLE
fix: webapp security hardening + CLI / keepa_service correctness

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -19,8 +19,16 @@ persist_user_env = false
 # Set to true to show API keys as ***, false to show them as plain text
 mask_user_env = false
 
-# Authorized origins
-allow_origins = ["*"]
+# Authorized origins (CORS allow-list).
+#
+# Default ships with localhost variants only. Production deployments behind
+# Caddy must extend this list with the public origin (https://$DOMAIN).
+# `deploy/entrypoint.sh` rewrites this line from the container's $DOMAIN env
+# var on startup so the running container reflects the actual public origin —
+# see deploy/README.md for the runbook. Do NOT put "*" here: that allows any
+# site on the internet to issue cross-origin requests against authenticated
+# sessions, which is the CSRF/clickjacking surface this list exists to close.
+allow_origins = ["http://localhost", "http://localhost:8000", "http://127.0.0.1", "http://127.0.0.1:8000"]
 
 [features]
 # Process and display HTML in messages. This can be a security risk (see https://stackoverflow.com/questions/19603097/why-is-it-dangerous-to-render-user-generated-html-or-javascript)
@@ -54,21 +62,18 @@ favorites = false
 # Add emoji reaction when message is received (requires reactions:write OAuth scope)
 reaction_on_message_received = false
 
-# Authorize users to spontaneously upload files with messages
+# Authorize users to spontaneously upload files with messages.
+#
+# DISABLED for amz-scout: the chat flow has no `@cl.on_file_upload` handler,
+# so accepting uploads would only burn disk and widen the attack surface
+# (large unrestricted uploads, MIME confusion, etc.). If a future feature
+# needs uploads, flip `enabled = true` AND tighten `accept` to a real
+# allow-list — never ship with "*/*" + 500 MB + 20 files.
 [features.spontaneous_file_upload]
-    enabled = true
-    # Define accepted file types using MIME types
-    # Examples:
-    # 1. For specific file types:
-    #    accept = ["image/jpeg", "image/png", "application/pdf"]
-    # 2. For all files of certain type:
-    #    accept = ["image/*", "audio/*", "video/*"]
-    # 3. For specific file extensions:
-    #    accept = { "application/octet-stream" = [".xyz", ".pdb"] }
-    # Note: Using "*/*" is not recommended as it may cause browser warnings
-    accept = ["*/*"]
-    max_files = 20
-    max_size_mb = 500
+    enabled = false
+    accept = ["image/jpeg", "image/png", "application/pdf"]
+    max_files = 5
+    max_size_mb = 25
 
 [features.audio]
     # Enable audio features

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,15 @@ RUN pip install --no-cache-dir -e ".[web]"
 COPY config/ config/
 COPY .chainlit/ .chainlit/
 COPY chainlit.md ./
+# Container entrypoint — rewrites .chainlit/config.toml `allow_origins` from
+# the runtime $DOMAIN env var BEFORE chainlit boots, then exec's chainlit.
+# See deploy/entrypoint.sh for the rationale.
+COPY deploy/entrypoint.sh ./deploy/entrypoint.sh
+RUN chmod +x ./deploy/entrypoint.sh
 
 EXPOSE 8000
 
-# `-h` is --headless (no auto-open browser on host).
-# Bind 0.0.0.0 so the container is reachable from the Docker network.
-# Do NOT use `-w` (watch mode) — that's dev-only.
-CMD ["chainlit", "run", "webapp/app.py", "-h", "--host", "0.0.0.0", "--port", "8000"]
+# Entrypoint handles CORS origin injection then exec's chainlit so PID 1
+# stays clean for signal handling. `-h` (=--headless) and `--host 0.0.0.0`
+# are baked into the entrypoint, not duplicated here.
+CMD ["bash", "deploy/entrypoint.sh"]

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -35,7 +35,7 @@ case "$DOMAIN" in
         ;;
     *)
         # Build the JSON-ish array literal that TOML accepts.
-        ALLOW_LIST="[\"https://${DOMAIN}\", \"http://localhost\", \"http://127.0.0.1\"]"
+        ALLOW_LIST="[\"https://${DOMAIN}\", \"http://localhost\", \"http://localhost:8000\", \"http://127.0.0.1\", \"http://127.0.0.1:8000\"]"
         # The sed pattern matches the exact line we shipped in .chainlit/config.toml.
         # We pin to `^allow_origins = ` so the comments above the line are untouched.
         sed -i "s|^allow_origins = .*|allow_origins = ${ALLOW_LIST}|" "$CONFIG_TOML"

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# amz-scout webapp container entrypoint.
+#
+# Why this script exists:
+#   chainlit reads `.chainlit/config.toml` exactly once at server-module
+#   import time and feeds `project.allow_origins` straight to Starlette's
+#   CORSMiddleware. Patching the config from inside `webapp/app.py` is too
+#   late — the middleware is already wired by the time our app module gets
+#   imported. So we rewrite the toml HERE, before exec'ing chainlit.
+#
+# What it does:
+#   1. If DOMAIN is set to a real public hostname, build an allow-list of
+#      [https://$DOMAIN, http://localhost, http://127.0.0.1] and sed it into
+#      the `allow_origins = ...` line in /app/.chainlit/config.toml.
+#   2. If DOMAIN is empty / "localhost" / ":80" (dev or HTTP-only rehearsal),
+#      leave the localhost-only default from the image as-is.
+#   3. Exec chainlit so it inherits PID 1 and signal handling stays clean.
+#
+# Idempotent: safe to run on every container start.
+
+set -euo pipefail
+
+CONFIG_TOML="/app/.chainlit/config.toml"
+
+if [[ ! -f "$CONFIG_TOML" ]]; then
+    echo "[entrypoint] FATAL: $CONFIG_TOML not found" >&2
+    exit 1
+fi
+
+DOMAIN="${DOMAIN:-}"
+
+case "$DOMAIN" in
+    "" | "localhost" | ":80")
+        echo "[entrypoint] DOMAIN='$DOMAIN' — keeping localhost-only allow_origins from image"
+        ;;
+    *)
+        # Build the JSON-ish array literal that TOML accepts.
+        ALLOW_LIST="[\"https://${DOMAIN}\", \"http://localhost\", \"http://127.0.0.1\"]"
+        # The sed pattern matches the exact line we shipped in .chainlit/config.toml.
+        # We pin to `^allow_origins = ` so the comments above the line are untouched.
+        sed -i "s|^allow_origins = .*|allow_origins = ${ALLOW_LIST}|" "$CONFIG_TOML"
+        echo "[entrypoint] allow_origins rewritten to: ${ALLOW_LIST}"
+        ;;
+esac
+
+exec chainlit run webapp/app.py -h --host 0.0.0.0 --port 8000

--- a/src/amz_scout/cli.py
+++ b/src/amz_scout/cli.py
@@ -66,16 +66,18 @@ def _setup_logging(verbose: bool = False) -> None:
 
 
 def _resolve_target_sites(info, products: list[Product], marketplace: str | None) -> list[str]:
-    """Compute target marketplaces from CLI flag, YAML config, or DB product overrides."""
-    return (
-        [marketplace]
-        if marketplace
-        else (
-            info.config.target_marketplaces
-            if info.config
-            else list({s for p in products for s in p.marketplace_overrides})
-        )
-    )
+    """Compute target marketplaces from CLI flag, YAML config, or DB product overrides.
+
+    The DB-derived branch goes through ``set`` to dedupe across products and
+    then ``sorted`` so the iteration order is stable across runs. Without the
+    sort, set hashing made the CLI output, CSV write order, and DB upsert
+    order non-deterministic, which is a pain for diffs and reproducibility.
+    """
+    if marketplace:
+        return [marketplace]
+    if info.config:
+        return info.config.target_marketplaces
+    return sorted({s for p in products for s in p.marketplace_overrides})
 
 
 @app.command()
@@ -91,7 +93,7 @@ def scrape(
     category: str | None = typer.Option(None, "-c", "--category", help="Filter by category"),
     data_only: bool = typer.Option(False, help="Skip Keepa price history"),
     history_only: bool = typer.Option(False, help="Only fetch Keepa price history"),
-    detailed: bool = typer.Option(False, help="Keepa detailed mode (~5 tokens/product vs 1)"),
+    detailed: bool = typer.Option(False, help="Keepa detailed mode (~6 tokens/product vs 1)"),
     headed: bool = typer.Option(False, help="Show browser window"),
     retry: int = typer.Option(3, "--retry", help="Retry count per product"),
     delay: int = typer.Option(2, "--delay", help="Delay between products (seconds)"),
@@ -173,7 +175,7 @@ def _scrape_price_history(
     db_conn=None,
 ) -> None:
     """Fetch Keepa price history."""
-    mode_label = "detailed ~5 tok/product" if detailed else "basic 1 tok/product"
+    mode_label = "detailed ~6 tok/product" if detailed else "basic 1 tok/product"
     console.print(f"\n[bold]── Price History ({mode_label}) ──[/]")
 
     # Try Keepa first
@@ -216,14 +218,17 @@ def _scrape_price_history(
             csv_path = data_dir / f"{site.lower()}_price_history.csv"
             merged = merge_price_history(read_price_history(csv_path), histories)
             write_price_history(merged, csv_path)
-            # DB write (fire-and-forget)
+            # DB write (fire-and-forget). Thread `detailed` through so the
+            # `fetch_mode` column on `keepa_products` reflects how this batch
+            # was fetched — otherwise it stays "basic" forever and freshness
+            # mode-upgrade logic can't tell whether a re-fetch is needed.
             if db_conn:
-                _store_raw_to_db(db_conn, raw_dir, products, site)
+                _store_raw_to_db(db_conn, raw_dir, products, site, detailed=detailed)
 
     if keepa:
         remaining = keepa.tokens_left
         total_products = len(products) * len(target_sites)
-        tok_per = 5 if detailed else 1
+        tok_per = 6 if detailed else 1
         tokens_used = total_products * tok_per
         console.print(f"  Keepa: ~{tokens_used} tokens used, {remaining} remaining")
         if remaining < total_products * tok_per:
@@ -699,9 +704,24 @@ def _validate_results(results: list[CompetitiveData], site: str) -> None:
             console.print(f"    [yellow]! {w}[/]")
 
 
-def _store_raw_to_db(db_conn, raw_dir: Path, products: list[Product], site: str) -> None:
-    """Import Keepa raw JSON into DB. Failures are logged, not raised."""
-    ok, fail = import_from_raw_json(db_conn, raw_dir, products, site)
+def _store_raw_to_db(
+    db_conn,
+    raw_dir: Path,
+    products: list[Product],
+    site: str,
+    detailed: bool = False,
+) -> None:
+    """Import Keepa raw JSON into DB. Failures are logged, not raised.
+
+    The ``detailed`` flag flows into the ``fetch_mode`` column on
+    ``keepa_products`` so the freshness layer can later decide whether a
+    cached row covers a basic vs detailed query. Without this the column
+    was permanently stuck at ``"basic"`` and any subsequent ``--detailed``
+    request would refuse to use the cache (or worse, silently drop the
+    detailed-only seller fields on read-back).
+    """
+    fetch_mode = "detailed" if detailed else "basic"
+    ok, fail = import_from_raw_json(db_conn, raw_dir, products, site, fetch_mode=fetch_mode)
     if fail:
         console.print(f"  [yellow]DB: {ok} stored, {fail} failed[/]")
 

--- a/src/amz_scout/db.py
+++ b/src/amz_scout/db.py
@@ -1503,7 +1503,18 @@ def import_from_raw_json(
     fetched_at: str | None = None,
     fetch_mode: str = "basic",
 ) -> tuple[int, int]:
-    """Import Keepa data from raw JSON files. Returns (ok, failed) counts."""
+    """Import Keepa data from raw JSON files. Returns (ok, failed) counts.
+
+    Per-file ``fetch_mode`` upgrade: callers that pass the default
+    ``"basic"`` (e.g. ``admin migrate`` / ``admin reparse``, which import
+    historical raw JSONs of mixed origin) get an auto-upgrade to
+    ``"detailed"`` for any individual file whose raw JSON contains a
+    non-empty ``offers`` array. That array is only present when the
+    original Keepa request was a ``--detailed`` fetch (``offers=20``), so
+    it's a safe per-file signal and avoids permanently mis-tagging rows
+    that should be ``"detailed"``. Explicit ``fetch_mode="detailed"``
+    callers are honored as-is and never downgraded.
+    """
     from amz_scout.utils import today_iso
 
     fetched = fetched_at or today_iso()
@@ -1516,7 +1527,11 @@ def import_from_raw_json(
         try:
             with open(json_path) as f:
                 raw = json_mod.load(f)
-            store_keepa_product(conn, asin, site, raw, fetched, fetch_mode=fetch_mode)
+            # Auto-upgrade only when the caller did not explicitly say "detailed".
+            effective_mode = fetch_mode
+            if effective_mode != "detailed" and raw.get("offers"):
+                effective_mode = "detailed"
+            store_keepa_product(conn, asin, site, raw, fetched, fetch_mode=effective_mode)
             ok += 1
         except Exception:
             logger.exception("Import failed for %s/%s", site, asin)

--- a/src/amz_scout/db.py
+++ b/src/amz_scout/db.py
@@ -1529,9 +1529,9 @@ def import_from_raw_json(
         try:
             with open(json_path) as f:
                 raw = json_mod.load(f)
-            # Auto-upgrade only when the caller did not explicitly say "detailed".
+            # Auto-upgrade only from the default "basic" mode.
             effective_mode = fetch_mode
-            if effective_mode != "detailed" and ("stats" in raw or "offers" in raw):
+            if effective_mode == "basic" and ("stats" in raw or "offers" in raw):
                 effective_mode = "detailed"
             store_keepa_product(conn, asin, site, raw, fetched, fetch_mode=effective_mode)
             ok += 1

--- a/src/amz_scout/db.py
+++ b/src/amz_scout/db.py
@@ -1529,7 +1529,7 @@ def import_from_raw_json(
                 raw = json_mod.load(f)
             # Auto-upgrade only when the caller did not explicitly say "detailed".
             effective_mode = fetch_mode
-            if effective_mode != "detailed" and raw.get("offers"):
+            if effective_mode != "detailed" and ("stats" in raw or "offers" in raw):
                 effective_mode = "detailed"
             store_keepa_product(conn, asin, site, raw, fetched, fetch_mode=effective_mode)
             ok += 1

--- a/src/amz_scout/db.py
+++ b/src/amz_scout/db.py
@@ -1508,12 +1508,14 @@ def import_from_raw_json(
     Per-file ``fetch_mode`` upgrade: callers that pass the default
     ``"basic"`` (e.g. ``admin migrate`` / ``admin reparse``, which import
     historical raw JSONs of mixed origin) get an auto-upgrade to
-    ``"detailed"`` for any individual file whose raw JSON contains a
-    non-empty ``offers`` array. That array is only present when the
-    original Keepa request was a ``--detailed`` fetch (``offers=20``), so
-    it's a safe per-file signal and avoids permanently mis-tagging rows
-    that should be ``"detailed"``. Explicit ``fetch_mode="detailed"``
-    callers are honored as-is and never downgraded.
+    ``"detailed"`` for any individual file whose raw JSON contains either
+    the ``stats`` key or the ``offers`` key. This check is based on key
+    presence, so ``offers: []`` still triggers the upgrade, and files with
+    ``stats`` but no offers do as well. These fields are treated as
+    per-file signals that the original Keepa request included detailed
+    data, avoiding permanently mis-tagging rows that should be
+    ``"detailed"``. Explicit ``fetch_mode="detailed"`` callers are honored
+    as-is and never downgraded.
     """
     from amz_scout.utils import today_iso
 

--- a/src/amz_scout/keepa_service.py
+++ b/src/amz_scout/keepa_service.py
@@ -222,15 +222,15 @@ def _raw_dir(output_base: Path, mp: MarketplaceConfig) -> Path:
 def _detailed_from_raw(raw: dict) -> bool:
     """Auto-detect whether a cached Keepa raw JSON came from a detailed fetch.
 
-    A ``--detailed`` Keepa request adds ``offers=20`` to the query, so the
-    response contains a non-empty ``offers`` array. Basic-mode responses do
-    not. Reading this signal off the cached JSON is more reliable than
-    threading a per-record fetch_mode flag through every caller, and it
-    keeps the cache round-trip lossless for ``seller_count`` /
-    ``fba_seller_count`` plus the pre-computed ``stats`` price block.
+    A ``--detailed`` Keepa request adds detailed-only fields such as
+    ``offers`` and the pre-computed ``stats`` block. Those keys may be
+    present even when ``offers`` is an empty list, so detection must use
+    key presence rather than offer-list truthiness. Reading this signal off
+    the cached JSON is more reliable than threading a per-record fetch_mode
+    flag through every caller, and it keeps the cache round-trip lossless
+    for ``seller_count`` / ``fba_seller_count`` plus ``stats``.
     """
-    offers = raw.get("offers")
-    return bool(offers)
+    return "stats" in raw or "offers" in raw
 
 
 def _read_from_cache(

--- a/src/amz_scout/keepa_service.py
+++ b/src/amz_scout/keepa_service.py
@@ -219,6 +219,20 @@ def _raw_dir(output_base: Path, mp: MarketplaceConfig) -> Path:
     return output_base / "data" / mp.region / "raw"
 
 
+def _detailed_from_raw(raw: dict) -> bool:
+    """Auto-detect whether a cached Keepa raw JSON came from a detailed fetch.
+
+    A ``--detailed`` Keepa request adds ``offers=20`` to the query, so the
+    response contains a non-empty ``offers`` array. Basic-mode responses do
+    not. Reading this signal off the cached JSON is more reliable than
+    threading a per-record fetch_mode flag through every caller, and it
+    keeps the cache round-trip lossless for ``seller_count`` /
+    ``fba_seller_count`` plus the pre-computed ``stats`` price block.
+    """
+    offers = raw.get("offers")
+    return bool(offers)
+
+
 def _read_from_cache(
     product: Product,
     site: str,
@@ -227,7 +241,10 @@ def _read_from_cache(
     """Read cached PriceHistory from raw JSON file.
 
     Uses the same _parse_product() as the API path, ensuring
-    identical output regardless of source.
+    identical output regardless of source. Detailed-mode caches are detected
+    automatically from the raw JSON content (see ``_detailed_from_raw``) so
+    detailed-only fields survive the round-trip without the caller having to
+    remember which mode the original fetch used.
     """
     if not raw_dir:
         return None
@@ -238,7 +255,7 @@ def _read_from_cache(
     try:
         with open(json_path) as f:
             raw = json_mod.load(f)
-        return _parse_product(product, site, raw, detailed=False)
+        return _parse_product(product, site, raw, detailed=_detailed_from_raw(raw))
     except Exception:
         logger.exception("Failed to read cache for %s/%s", site, asin)
         return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,75 @@
+"""Unit tests for thin helpers inside `amz_scout.cli`.
+
+The CLI command bodies themselves are exercised end-to-end by the wider test
+suite via ``amz_scout.api`` (which the CLI delegates to). This file only
+covers the stand-alone helpers whose contracts are easy to pin down without
+spinning up Typer or the DB.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from amz_scout.cli import _resolve_target_sites
+from amz_scout.models import Product
+
+
+def _product_with_overrides(*sites: str) -> Product:
+    # `marketplace_overrides` is dict[str, dict[str, str]]: the outer key is the
+    # marketplace code (which is what `_resolve_target_sites` iterates over) and
+    # the inner dict carries the actual ASIN / note for that marketplace.
+    return Product(
+        category="Router",
+        brand="Vendor",
+        model=f"M-{'-'.join(sites)}",
+        default_asin="B0DEFAULT0",
+        marketplace_overrides={s: {"asin": f"B0{s}000000"} for s in sites},
+    )
+
+
+@pytest.mark.unit
+class TestResolveTargetSites:
+    """Regression guard for deterministic CLI target-site ordering.
+
+    Before the fix, `_resolve_target_sites` returned ``list({set comprehension})``
+    in the DB-only branch, so the iteration order changed across runs (Python
+    set ordering depends on hash randomization). That bled into CLI output
+    rendering, downstream CSV write order, and DB upsert order — anywhere
+    "the same command" should produce a stable diff.
+    """
+
+    def test_marketplace_flag_short_circuits(self):
+        """Explicit `-m UK` always wins, regardless of products/config."""
+        info = SimpleNamespace(config=None)
+        assert _resolve_target_sites(info, [], "UK") == ["UK"]
+
+    def test_yaml_config_branch_passes_through(self):
+        """When `info.config` is present, the YAML's target_marketplaces wins
+        and ordering is whatever YAML preserved (no re-sort needed)."""
+        info = SimpleNamespace(
+            config=SimpleNamespace(target_marketplaces=["UK", "DE", "FR"]),
+        )
+        assert _resolve_target_sites(info, [], None) == ["UK", "DE", "FR"]
+
+    def test_db_only_branch_is_sorted(self):
+        """No CLI flag, no YAML — DB product overrides feed the list. Output
+        must be lexicographically sorted, deduped, and stable across runs."""
+        info = SimpleNamespace(config=None)
+        products = [
+            _product_with_overrides("US", "DE"),
+            _product_with_overrides("UK", "DE"),
+            _product_with_overrides("JP"),
+        ]
+        result = _resolve_target_sites(info, products, None)
+        assert result == ["DE", "JP", "UK", "US"]
+
+    def test_db_only_branch_is_stable_across_calls(self):
+        """Same inputs → same outputs, every call. Without the explicit sort,
+        Python's hash randomization could surface different orderings between
+        CLI invocations even within the same interpreter session."""
+        info = SimpleNamespace(config=None)
+        products = [_product_with_overrides("US", "DE", "UK", "JP", "BR")]
+        first = _resolve_target_sites(info, products, None)
+        second = _resolve_target_sites(info, products, None)
+        third = _resolve_target_sites(info, products, None)
+        assert first == second == third == ["BR", "DE", "JP", "UK", "US"]

--- a/tests/test_keepa_service.py
+++ b/tests/test_keepa_service.py
@@ -10,7 +10,7 @@ import pytest
 from amz_scout.config import MarketplaceConfig
 from amz_scout.db import init_schema, store_keepa_product
 from amz_scout.freshness import FreshnessStrategy
-from amz_scout.keepa_service import _read_from_cache, get_keepa_data
+from amz_scout.keepa_service import _detailed_from_raw, _read_from_cache, get_keepa_data
 from amz_scout.models import PriceHistory, Product
 
 # raw_data fixture is provided by conftest.py (synthetic + real fallback)
@@ -100,6 +100,38 @@ class TestReadFromCache:
             assert result is not None
             assert result.seller_count == 2
             assert result.fba_seller_count == 1
+
+
+    def test_detects_detailed_mode_from_empty_offers(self, raw_data):
+        """A cached raw JSON with ``offers: []`` must still be detected as
+        detailed mode. Regression: ``bool([])`` is False, so the old
+        truthiness check mis-classified detailed caches with zero offers.
+        """
+        import copy
+
+        raw = copy.deepcopy(raw_data)
+        raw["offers"] = []
+        raw["stats"] = {"min": [0], "max": [100]}
+
+        assert _detailed_from_raw(raw) is True
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir)
+            with open(raw_dir / "uk_B0F2MR53D6.json", "w") as f:
+                json.dump(raw, f)
+
+            result = _read_from_cache(_product(), "UK", raw_dir)
+            assert result is not None
+
+    def test_basic_mode_when_no_detailed_keys(self, raw_data):
+        """A raw JSON without ``offers`` or ``stats`` keys is basic mode."""
+        import copy
+
+        raw = copy.deepcopy(raw_data)
+        raw.pop("offers", None)
+        raw.pop("stats", None)
+
+        assert _detailed_from_raw(raw) is False
 
 
 class TestGetKeepaDataOffline:

--- a/tests/test_keepa_service.py
+++ b/tests/test_keepa_service.py
@@ -74,6 +74,33 @@ class TestReadFromCache:
         result = _read_from_cache(_product(), "UK", None)
         assert result is None
 
+    def test_detects_detailed_mode_from_offers(self, raw_data):
+        """A cached raw JSON with a non-empty `offers` array must be parsed
+        in detailed mode so detailed-only seller fields survive the round-trip.
+
+        Regression guard for the keepa_service correctness fix: previously
+        `_read_from_cache` hardcoded `detailed=False`, which silently dropped
+        `seller_count` and `fba_seller_count` whenever the original Keepa
+        fetch had been a `--detailed` request.
+        """
+        import copy
+
+        raw = copy.deepcopy(raw_data)
+        raw["offers"] = [
+            {"sellerId": "AXX", "isFBA": True},
+            {"sellerId": "AYY", "isFBA": False},
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir)
+            with open(raw_dir / "uk_B0F2MR53D6.json", "w") as f:
+                json.dump(raw, f)
+
+            result = _read_from_cache(_product(), "UK", raw_dir)
+            assert result is not None
+            assert result.seller_count == 2
+            assert result.fba_seller_count == 1
+
 
 class TestGetKeepaDataOffline:
     """Test offline strategy — no API calls, purely DB + cache."""

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -101,6 +101,25 @@ class TestEmailDomainNormalization:
         assert not "attacker@evilgl-inet.com".endswith(normalized)
         assert "alice@gl-inet.com".endswith(normalized)
 
+    def test_empty_domain_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty ALLOWED_EMAIL_DOMAIN must fall back to the default
+        rather than silently producing '@' which locks out all users.
+        """
+        _set_fake_env(monkeypatch)
+        monkeypatch.setenv("ALLOWED_EMAIL_DOMAIN", "")
+        _reset_webapp_modules()
+        from webapp import config
+
+        assert config.ALLOWED_EMAIL_DOMAIN == "@gl-inet.com"
+
+    def test_whitespace_only_domain_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_fake_env(monkeypatch)
+        monkeypatch.setenv("ALLOWED_EMAIL_DOMAIN", "   ")
+        _reset_webapp_modules()
+        from webapp import config
+
+        assert config.ALLOWED_EMAIL_DOMAIN == "@gl-inet.com"
+
 
 @pytest.mark.unit
 class TestToolDispatch:

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -51,6 +51,58 @@ class TestWebappImports:
 
 
 @pytest.mark.unit
+class TestEmailDomainNormalization:
+    """Regression guard for the auth domain anchor.
+
+    ``webapp.config.ALLOWED_EMAIL_DOMAIN`` MUST always start with "@" and be
+    lowercased, regardless of how the operator wrote the env var. Without
+    this normalization, an env value of "gl-inet.com" (no leading "@") would
+    let "attacker@evilgl-inet.com" satisfy ``email.endswith(domain)`` and
+    bypass the email whitelist entirely.
+    """
+
+    def test_default_value_already_anchored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_fake_env(monkeypatch)
+        monkeypatch.delenv("ALLOWED_EMAIL_DOMAIN", raising=False)
+        _reset_webapp_modules()
+        from webapp import config
+
+        assert config.ALLOWED_EMAIL_DOMAIN == "@gl-inet.com"
+
+    def test_missing_at_prefix_is_added(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_fake_env(monkeypatch)
+        monkeypatch.setenv("ALLOWED_EMAIL_DOMAIN", "gl-inet.com")
+        _reset_webapp_modules()
+        from webapp import config
+
+        assert config.ALLOWED_EMAIL_DOMAIN == "@gl-inet.com"
+
+    def test_uppercase_input_is_lowercased(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_fake_env(monkeypatch)
+        monkeypatch.setenv("ALLOWED_EMAIL_DOMAIN", "GL-INET.COM")
+        _reset_webapp_modules()
+        from webapp import config
+
+        assert config.ALLOWED_EMAIL_DOMAIN == "@gl-inet.com"
+
+    def test_lookalike_domain_does_not_satisfy_endswith(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The whole point of the anchor: a normalized domain must reject
+        ``attacker@evilgl-inet.com``. We verify by hand-rolling the same
+        ``endswith`` check ``webapp.auth`` uses, against the normalized value.
+        """
+        _set_fake_env(monkeypatch)
+        monkeypatch.setenv("ALLOWED_EMAIL_DOMAIN", "gl-inet.com")  # no "@"
+        _reset_webapp_modules()
+        from webapp import config
+
+        normalized = config.ALLOWED_EMAIL_DOMAIN
+        assert not "attacker@evilgl-inet.com".endswith(normalized)
+        assert "alice@gl-inet.com".endswith(normalized)
+
+
+@pytest.mark.unit
 class TestToolDispatch:
     """Verify tool dispatch returns the amz_scout.api envelope shape."""
 
@@ -284,9 +336,7 @@ class TestWebappTrimBoundary:
             )
         assert result["meta"] == {"count": 1, "auto_fetched": False}
 
-    def test_query_trends_timeseries_is_trimmed(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_query_trends_timeseries_is_trimmed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _set_fake_env(monkeypatch)
         self._patch_chainlit_step(monkeypatch)
         _reset_webapp_modules()
@@ -328,9 +378,7 @@ class TestWebappTrimBoundary:
             )
         assert result["meta"]["asin"] == "B0TEST"
 
-    def test_query_deals_envelope_is_trimmed(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_query_deals_envelope_is_trimmed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _set_fake_env(monkeypatch)
         self._patch_chainlit_step(monkeypatch)
         _reset_webapp_modules()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -46,9 +46,18 @@ async def on_message(msg: cl.Message) -> None:
 
     try:
         final_text, updated_history = await run_chat_turn(history)
-    except Exception as e:
+    except Exception:
+        # Keep stack + exception detail in server logs only — never echo the
+        # raw exception to authenticated users since it can leak file paths,
+        # configuration values, or internal error strings. Operators read the
+        # actual cause from `logger.exception` server-side.
         logger.exception("run_chat_turn failed")
-        await cl.Message(content=f"⚠️ Sorry, something went wrong: {e}").send()
+        await cl.Message(
+            content=(
+                "⚠️ Sorry, something went wrong on the server. "
+                "Please try again — if it keeps happening, ping the operator."
+            )
+        ).send()
         return
 
     cl.user_session.set("history", updated_history)

--- a/webapp/auth.py
+++ b/webapp/auth.py
@@ -1,6 +1,7 @@
 """Chainlit password auth callback with @gl-inet.com email whitelist."""
 
 import logging
+import secrets
 
 import chainlit as cl
 
@@ -15,10 +16,17 @@ def auth_callback(username: str, password: str) -> cl.User | None:
 
     Phase 1 MVP: all @gl-inet.com emails share a single APP_PASSWORD.
     Phase 6 will replace this with per-user bcrypt hashes.
+
+    Notes:
+        - ``ALLOWED_EMAIL_DOMAIN`` is normalized in ``webapp.config`` to always
+          start with "@" and to be lowercased, so a plain ``endswith`` here is
+          safe against the ``attacker@evilgl-inet.com`` lookalike attack.
+        - Password comparison goes through ``secrets.compare_digest`` to remove
+          the timing side channel that ``!=`` would expose.
     """
     email = username.strip().lower()
 
-    if not email.endswith(ALLOWED_EMAIL_DOMAIN.lower()):
+    if not email.endswith(ALLOWED_EMAIL_DOMAIN):
         logger.warning(
             "Auth rejected: email %r not in allowed domain %s",
             email,
@@ -30,7 +38,7 @@ def auth_callback(username: str, password: str) -> cl.User | None:
         logger.error("APP_PASSWORD is empty — all auth will fail")
         return None
 
-    if password != APP_PASSWORD:
+    if not secrets.compare_digest(password, APP_PASSWORD):
         logger.warning("Auth rejected: wrong password for %s", email)
         return None
 

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -29,7 +29,13 @@ SYSTEM_PROMPT = (
 )
 
 # ─── Auth ────────────────────────────────────────────────────────
-ALLOWED_EMAIL_DOMAIN = os.environ.get("ALLOWED_EMAIL_DOMAIN", "@gl-inet.com")
+# Always anchor the domain with a leading "@" so endswith() can't be tricked
+# by a lookalike like "attacker@evilgl-inet.com" when the operator forgets the
+# "@" in their .env. We also lowercase here so callers don't have to.
+_raw_allowed_domain = os.environ.get("ALLOWED_EMAIL_DOMAIN", "@gl-inet.com").strip().lower()
+if not _raw_allowed_domain.startswith("@"):
+    _raw_allowed_domain = "@" + _raw_allowed_domain
+ALLOWED_EMAIL_DOMAIN = _raw_allowed_domain
 APP_PASSWORD = os.environ.get("APP_PASSWORD", "")
 
 # ─── Database ────────────────────────────────────────────────────

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -33,7 +33,11 @@ SYSTEM_PROMPT = (
 # by a lookalike like "attacker@evilgl-inet.com" when the operator forgets the
 # "@" in their .env. We also lowercase here so callers don't have to.
 _raw_allowed_domain = os.environ.get("ALLOWED_EMAIL_DOMAIN", "@gl-inet.com").strip().lower()
-if not _raw_allowed_domain.startswith("@"):
+if not _raw_allowed_domain or _raw_allowed_domain == "@":
+    # Empty / whitespace-only env var → fall back to default instead of
+    # silently producing "@" which would lock out all users.
+    _raw_allowed_domain = "@gl-inet.com"
+elif not _raw_allowed_domain.startswith("@"):
     _raw_allowed_domain = "@" + _raw_allowed_domain
 ALLOWED_EMAIL_DOMAIN = _raw_allowed_domain
 APP_PASSWORD = os.environ.get("APP_PASSWORD", "")


### PR DESCRIPTION
## Summary

Address the high-priority Copilot review feedback from PRs #1, #3, #4 that hadn't been actioned yet. Two themes bundled in one PR:

- **Webapp security hardening** (5 items): timing-safe auth, anchored email-domain whitelist, no exception leakage to UI, narrowed CORS, disabled file upload.
- **CLI / keepa_service correctness** (3 items): right `--detailed` token estimate, deterministic target-site ordering, lossless `fetch_mode` round-trip from raw JSON cache → SQLite.

Plus 9 new unit tests as regression guards, and an entrypoint script that lets the CORS narrowing actually work in production (chainlit reads `allow_origins` once at server-module import, so a Python-level override is too late).

## Webapp security hardening

| File | Change |
|---|---|
| \`webapp/config.py\` | Normalize \`ALLOWED_EMAIL_DOMAIN\` to always start with \`@\` (lowercased). Closes the lookalike attack where \`ALLOWED_EMAIL_DOMAIN=gl-inet.com\` (no \`@\`) would let \`attacker@evilgl-inet.com\` pass \`endswith()\`. |
| \`webapp/auth.py\` | \`secrets.compare_digest\` instead of \`!=\` to remove the timing side channel. Drop the now-redundant \`.lower()\` on the anchored domain. |
| \`webapp/app.py\` | Stop sending raw \`{e}\` to the chat UI on \`run_chat_turn\` failure — UI gets a generic message, full stack stays in \`logger.exception\`. |
| \`.chainlit/config.toml\` | Replace \`allow_origins = [\"*\"]\` with localhost-only default. Disable \`spontaneous_file_upload\` (the chat flow has no upload handler). |
| \`deploy/entrypoint.sh\` (NEW) + \`Dockerfile\` | New container entrypoint sed-rewrites \`.chainlit/config.toml\` \`allow_origins\` from \`\$DOMAIN\` before exec'ing chainlit. Required because chainlit wires \`CORSMiddleware\` at server-module import time, before \`webapp/app.py\` ever runs. Idempotent — \`DOMAIN\` empty/\`localhost\`/\`:80\` keeps the localhost default for dev. |

## CLI / keepa_service correctness

| File | Change |
|---|---|
| \`src/amz_scout/cli.py\` | \`--detailed\` help, \`_scrape_price_history\` mode label, and \`tok_per\` summary now say \`~6\` instead of \`~5\` tokens/product (KeepaClient adds \`rating=1\` so the real cost is 6). |
| \`src/amz_scout/cli.py\` | \`_resolve_target_sites\` now \`sorted({set})\` instead of \`list({set})\` — output, CSV write order, and DB upsert order are stable across runs. |
| \`src/amz_scout/cli.py\` | \`_store_raw_to_db\` accepts \`detailed: bool\` and threads it as \`fetch_mode\` into \`import_from_raw_json\`, so \`keepa_products.fetch_mode\` finally reflects how the batch was fetched. \`_scrape_price_history\` call site updated. |
| \`src/amz_scout/keepa_service.py\` | New \`_detailed_from_raw\` helper. \`_read_from_cache\` now auto-detects detailed mode from the cached raw JSON's \`offers\` array, so \`seller_count\` / \`fba_seller_count\` survive the cache round-trip. |
| \`src/amz_scout/db.py\` | \`import_from_raw_json\` per-file \`fetch_mode\` upgrade — when the caller passes the default \`\"basic\"\` and the loaded raw JSON has \`offers\`, store as \`\"detailed\"\`. Explicit \`fetch_mode=\"detailed\"\` is honored as-is and never downgraded. Unblocks \`admin migrate\` / \`admin reparse\` from mis-tagging historical detailed-mode raws. |

## Tests added

| Test | What it pins |
|---|---|
| \`test_webapp_smoke.py::TestEmailDomainNormalization\` (4 tests) | Default value, missing-\`@\` normalization, uppercase lowercased, lookalike attack rejected |
| \`test_keepa_service.py::TestReadFromCache::test_detects_detailed_mode_from_offers\` | Injects \`offers\` into cached raw, asserts \`seller_count\`/\`fba_seller_count\` survive |
| \`tests/test_cli.py\` (NEW, 4 tests) | \`_resolve_target_sites\` flag short-circuit, YAML pass-through, sorted DB-only branch, stable across calls |

## Test plan

- [x] \`ruff check src/ tests/ webapp/\` — clean
- [x] \`ruff format src/ tests/ webapp/\` — applied
- [x] \`pytest -q tests/\` — **262 pass / 7 skip / 2 fail**
  - The 2 failures (\`test_token_audit.py::test_query_{trends,deals}_token_delta\`) are **pre-existing on \`main\`** — Anthropic's \`count_tokens\` endpoint reports trimmed envelopes as larger than untrimmed for the current production DB. Tokenizer-side drift unrelated to this branch (verified by running the same test on \`main\`).
- [ ] **Deferred to next deploy session** (per Daisy's request, recorded in \`memory/project_deploy_script_todos.md\`):
  - \`scripts/smoke_deploy.sh\` add \`-L\`
  - \`scripts/smoke_deploy.sh\` body match aligned with pytest
  - \`deploy/first-time-setup.sh\` /etc/fstab use \`LABEL=amz-scout-data\`
  - \`deploy/README.md\` drop the obsolete Playwright troubleshooting note

🤖 Generated with [Claude Code](https://claude.com/claude-code)