### PR TITLE
fix: align meta in token audit before-envelopes to prevent flaky failures

### DIFF
--- a/tests/test_token_audit.py
+++ b/tests/test_token_audit.py
@@ -47,9 +47,13 @@ def audit_path() -> Path:
     return out
 
 
-def _envelope_untrimmed(data: list[dict]) -> dict:
-    """Wrap raw DB rows in an envelope matching the public shape but with no trim."""
-    return {"ok": True, "data": data, "error": None, "meta": {}}
+def _envelope_untrimmed(data: list[dict], meta: dict | None = None) -> dict:
+    """Wrap raw DB rows in an envelope matching the public shape but with no trim.
+
+    When *meta* is provided the before-envelope carries the same metadata as the
+    after-envelope so the token delta isolates the ``data`` field difference only.
+    """
+    return {"ok": True, "data": data, "error": None, "meta": meta if meta is not None else {}}
 
 
 def _count_tokens_for_tool_result(client: Any, payload: dict) -> int:
@@ -136,7 +140,7 @@ def test_query_latest_token_delta(
     if not raw:
         pytest.skip("competitive_snapshots has no UK rows — trim measurement is meaningless")
     after_env = amz_api.query_latest(marketplace="UK")
-    before_env = _envelope_untrimmed(raw)
+    before_env = _envelope_untrimmed(raw, meta=after_env.get("meta", {}))
 
     before = _count_tokens_for_tool_result(anthropic_client, before_env)
     after = _count_tokens_for_tool_result(anthropic_client, after_env)
@@ -156,7 +160,7 @@ def test_query_ranking_token_delta(
     if not raw:
         pytest.skip("no BSR ranking rows for UK — trim measurement is meaningless")
     after_env = amz_api.query_ranking(marketplace="UK")
-    before_env = _envelope_untrimmed(raw)
+    before_env = _envelope_untrimmed(raw, meta=after_env.get("meta", {}))
 
     before = _count_tokens_for_tool_result(anthropic_client, before_env)
     after = _count_tokens_for_tool_result(anthropic_client, after_env)
@@ -177,7 +181,7 @@ def test_query_availability_token_delta(
     if not raw:
         pytest.skip("no availability rows — trim measurement is meaningless")
     after_env = amz_api.query_availability()
-    before_env = _envelope_untrimmed(raw)
+    before_env = _envelope_untrimmed(raw, meta=after_env.get("meta", {}))
 
     before = _count_tokens_for_tool_result(anthropic_client, before_env)
     after = _count_tokens_for_tool_result(anthropic_client, after_env)
@@ -202,7 +206,7 @@ def test_query_compare_token_delta(
     after_env = amz_api.query_compare(product=model)
     with open_db(real_db) as conn:
         raw = query_cross_market(conn, model)
-    before_env = _envelope_untrimmed(raw)
+    before_env = _envelope_untrimmed(raw, meta=after_env.get("meta", {}))
 
     before = _count_tokens_for_tool_result(anthropic_client, before_env)
     after = _count_tokens_for_tool_result(anthropic_client, after_env)
@@ -246,7 +250,7 @@ def test_query_trends_token_delta(
         }
         for r in raw
     ]
-    before_env = _envelope_untrimmed(dated)
+    before_env = _envelope_untrimmed(dated, meta=after_env.get("meta", {}))
 
     before = _count_tokens_for_tool_result(anthropic_client, before_env)
     after = _count_tokens_for_tool_result(anthropic_client, after_env)
@@ -281,7 +285,7 @@ def test_query_sellers_token_delta(
         }
         for r in raw
     ]
-    before_env = _envelope_untrimmed(dated)
+    before_env = _envelope_untrimmed(dated, meta=after_env.get("meta", {}))
 
     before = _count_tokens_for_tool_result(anthropic_client, before_env)
     after = _count_tokens_for_tool_result(anthropic_client, after_env)
@@ -301,7 +305,7 @@ def test_query_deals_token_delta(
     if not raw:
         pytest.skip("no deals rows for UK — trim measurement is meaningless")
     after_env = amz_api.query_deals(marketplace="UK", auto_fetch=False)
-    before_env = _envelope_untrimmed(raw)
+    before_env = _envelope_untrimmed(raw, meta=after_env.get("meta", {}))
 
     before = _count_tokens_for_tool_result(anthropic_client, before_env)
     after = _count_tokens_for_tool_result(anthropic_client, after_env)


### PR DESCRIPTION
## Summary

- `test_query_trends_token_delta` and `test_query_deals_token_delta` failed on main because the "before" envelope had empty `meta: {}` while the API-returned "after" envelope included populated meta (`asin`, `model`, `series_name`, `count`, etc.). With small datasets the meta overhead alone made `after > before`, tripping the non-regression assert.
- Fix: pass `after_env["meta"]` into `_envelope_untrimmed()` so both envelopes share identical meta, isolating the measurement to the `data` field only.
- Applied the same fix to all 7 live-DB audit tests for consistency — the other 5 happened to pass only because their data rows were large enough to dwarf the meta overhead.

## Test plan

- [x] `ruff check` passes
- [x] All 252 non-network tests pass (`pytest -m "not network"`)
- [ ] Run `pytest tests/test_token_audit.py -m network` with `ANTHROPIC_API_KEY` and live DB to confirm the two previously-flaky tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)