### PR TITLE
fix: make register_product race-safe via atomic UPSERT

### DIFF
--- a/.claude/PRPs/plans/completed/register-product-toctou-fix.plan.md
+++ b/.claude/PRPs/plans/completed/register-product-toctou-fix.plan.md
@@ -1,0 +1,444 @@
+# Plan: Fix `register_product` TOCTOU race
+
+## Summary
+
+`register_product` currently reads the row with a bare `SELECT`, then
+inserts under `with conn:`. Between the SELECT and the INSERT a second
+writer can claim the same `(brand_key, model_key)`, causing the second
+caller to raise `sqlite3.IntegrityError` instead of the documented
+`(existing_id, False)` return. Collapse the pattern into a single
+`INSERT ... ON CONFLICT(brand_key, model_key) DO NOTHING RETURNING id`
+statement with a `SELECT` fallback for the conflict path. This matches
+the upsert precedent already used by `register_asin`.
+
+## User Story
+
+As the webapp process (or any multi-process caller), I want concurrent
+`register_product` calls for the same normalized (brand, model) to
+return `(existing_id, False)` for the losers, so that a Keepa-fetch
+burst does not crash with `IntegrityError`.
+
+## Problem → Solution
+
+**Current**: SELECT → (context-switch) → another writer INSERTs same
+key → our INSERT raises `sqlite3.IntegrityError` out of `register_product`,
+breaking the documented `(int, bool)` contract.
+
+**Desired**: One atomic SQL statement resolves insert-or-exist. Losers
+fall back to one extra SELECT to fetch the canonical id. Never raises
+on duplicate-key races.
+
+## Metadata
+
+- **Complexity**: Small
+- **Source PRD**: N/A (follow-up from PR #15 code-review)
+- **PRD Phase**: N/A
+- **Estimated Files**: 2 (1 source, 1 test)
+
+---
+
+## UX Design
+
+Internal change — no user-facing UX transformation. Webapp error-rate
+under concurrent load goes from "rare 500 on duplicate registration"
+to "0 on duplicate registration".
+
+### Interaction Changes
+
+| Touchpoint | Before | After | Notes |
+|---|---|---|---|
+| `register_product()` under race | `sqlite3.IntegrityError` raised | Returns `(existing_id, False)` | Single-process CLI unaffected |
+
+---
+
+## Mandatory Reading
+
+| Priority | File | Lines | Why |
+|---|---|---|---|
+| **P0** | `src/amz_scout/db.py` | 1595-1628 | `register_product` — function being modified |
+| **P0** | `src/amz_scout/db.py` | 1631-1648 | `register_asin` — precedent for `ON CONFLICT` usage in this file |
+| P1 | `src/amz_scout/db.py` | 709-726 | `products` table DDL — confirms `UNIQUE(brand_key, model_key)` is the conflict target |
+| P1 | `src/amz_scout/db.py` | 838-846 | `_normalize_key` — used to build the conflict keys |
+| P1 | `tests/test_db.py` | 528-600 | `TestBrandModelKeyMigrationV7` — style reference for new-in-scope tests |
+| P2 | `tests/test_db.py` | 540-555 | `test_v7_register_product_matches_whitespace_variants` — closest existing behavior test |
+
+## External Documentation
+
+| Topic | Source | Key Takeaway |
+|---|---|---|
+| SQLite `ON CONFLICT DO NOTHING RETURNING id` | https://sqlite.org/lang_returning.html | RETURNING is only emitted for rows that were actually INSERTed. DO NOTHING + conflict → zero rows returned. This is exactly the signal we need. |
+| SQLite UPSERT | https://sqlite.org/lang_upsert.html | Requires ≥3.24 (ON CONFLICT). RETURNING requires ≥3.35. This repo runs Python ≥3.12 → stdlib sqlite3 ships SQLite ≥3.40, so both are safe. |
+| Python sqlite3 isolation | https://docs.python.org/3/library/sqlite3.html | `with conn:` commits on success / rolls back on exception. Implicit transaction covers exactly one statement run in our case — good enough for this atomic upsert. |
+
+### Research Notes
+
+```
+KEY_INSIGHT: `INSERT ... ON CONFLICT(...) DO NOTHING RETURNING id`
+returns exactly one row on a fresh insert, zero rows on conflict.
+APPLIES_TO: The `register_product` rewrite.
+GOTCHA: Python's `sqlite3.Cursor.fetchone()` returns `None` on zero
+rows, which is the canonical "conflict happened" signal. `lastrowid`
+is unreliable on the conflict path (unchanged from prior statement).
+
+KEY_INSIGHT: `register_asin` at db.py:1640-1648 already uses
+`ON CONFLICT(product_id, marketplace) DO UPDATE`. Same mechanic, just
+DO NOTHING instead of DO UPDATE.
+APPLIES_TO: Pattern faithfulness — the new `register_product` should
+read like a sibling of `register_asin`, not invent a new style.
+
+KEY_INSIGHT: The `with conn:` block is required to hold the transaction
+over the INSERT + conditional SELECT, so the fallback SELECT sees the
+committed winning row. Without it the SELECT could race back to empty
+if the winner's transaction hasn't committed yet.
+APPLIES_TO: Task 1 structure.
+GOTCHA: Do NOT call `conn.commit()` manually; `with conn:` owns commit.
+```
+
+---
+
+## Patterns to Mirror
+
+### UPSERT_WITH_ON_CONFLICT
+```python
+# SOURCE: src/amz_scout/db.py:1640-1648 (register_asin)
+with conn:
+    conn.execute(
+        "INSERT INTO product_asins (product_id, marketplace, asin, status, notes) "
+        "VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT(product_id, marketplace) DO UPDATE SET "
+        "asin=excluded.asin, status=excluded.status, notes=excluded.notes, "
+        "updated_at=strftime('%Y-%m-%dT%H:%M:%SZ', 'now')",
+        (product_id, marketplace, asin, status, notes),
+    )
+```
+
+### NORMALIZE_KEY_USAGE
+```python
+# SOURCE: src/amz_scout/db.py:1613-1614 (current register_product)
+brand_key = _normalize_key(brand)
+model_key = _normalize_key(model)
+```
+
+### RETURN_SHAPE
+```python
+# SOURCE: src/amz_scout/db.py:1610-1611 (docstring contract — MUST preserve)
+# Returns ``(product_id, is_new)`` where *is_new* is True when the row
+# was just inserted.
+```
+
+### TEST_STRUCTURE
+```python
+# SOURCE: tests/test_db.py:540-555 (TestBrandModelKeyMigrationV7)
+def test_v7_register_product_matches_whitespace_variants(self, conn):
+    from amz_scout.db import register_product
+
+    pid1, new1 = register_product(conn, "Router", "TP-Link", "Archer BE400")
+    pid2, new2 = register_product(conn, "Router", "  tp-link  ", "archer  be400")
+    ...
+    assert pid1 == pid2
+    assert new1 is True
+    assert new2 is False
+```
+
+### TEST_CONCURRENCY (no prior art — this plan introduces it)
+```python
+# Concurrency-test skeleton (new in this PR; use threading + file-backed
+# DB because :memory: is connection-local in sqlite3):
+import threading
+import sqlite3
+
+def _worker(db_path, brand, model, results, idx):
+    c = sqlite3.connect(db_path, timeout=5.0)
+    c.row_factory = sqlite3.Row
+    try:
+        results[idx] = register_product(c, "Router", brand, model)
+    finally:
+        c.close()
+```
+
+---
+
+## Files to Change
+
+| File | Action | Justification |
+|---|---|---|
+| `src/amz_scout/db.py` | UPDATE | Rewrite `register_product` (lines 1595-1628) to a single UPSERT with RETURNING. |
+| `tests/test_db.py` | UPDATE | Add `TestRegisterProductConcurrency` class: one test proves race-safety, one test documents the first-writer-wins display literal under race. |
+
+## NOT Building
+
+- A new helper or abstraction for UPSERT (the pattern is three lines — inline is correct).
+- A retry loop on `IntegrityError` (the new statement cannot raise that).
+- Changes to `find_product_exact`, `list_registered_products`, or `load_products_from_db` (already fixed in PR #15).
+- Changes to `_find_product_by_ean` normalization drift (tracked separately under issue #12).
+- A connection pool or lock manager (out of scope — sqlite3 already serializes writers at the file level).
+- Docs/CLAUDE.md rule update (the behavioral contract is unchanged; only the crash mode is fixed).
+
+---
+
+## Step-by-Step Tasks
+
+### Task 1: Rewrite `register_product` as single-statement UPSERT with fallback
+
+- **ACTION**: Replace the bare SELECT → `with conn:` INSERT pair with a single `INSERT ... ON CONFLICT(brand_key, model_key) DO NOTHING RETURNING id` under `with conn:`. If `fetchone()` returns a row, return `(id, True)`. Otherwise, the conflict path was taken — run the same normalized SELECT and return `(id, False)`.
+- **IMPLEMENT**: Inside `register_product` at `src/amz_scout/db.py:1595-1628`, replace lines 1615-1628 (keep lines 1613-1614 that compute `brand_key`/`model_key`, keep the docstring at 1602-1612) with:
+  ```python
+  with conn:
+      row = conn.execute(
+          "INSERT INTO products "
+          "(category, brand, model, brand_key, model_key, search_keywords) "
+          "VALUES (?, ?, ?, ?, ?, ?) "
+          "ON CONFLICT(brand_key, model_key) DO NOTHING "
+          "RETURNING id",
+          (category, brand, model, brand_key, model_key, search_keywords),
+      ).fetchone()
+  if row is not None:
+      return row["id"], True
+  # Conflict path: another writer (or a prior call) owns the row.
+  # Fetch the canonical id and return is_new=False.
+  existing = conn.execute(
+      "SELECT id FROM products WHERE brand_key = ? AND model_key = ?",
+      (brand_key, model_key),
+  ).fetchone()
+  return existing["id"], False
+  ```
+- **MIRROR**: `UPSERT_WITH_ON_CONFLICT` pattern (from `register_asin` at `db.py:1640-1648`). The `ON CONFLICT(...)` column list is the declared `UNIQUE(brand_key, model_key)` constraint from `db.py:725`.
+- **IMPORTS**: No new imports. `_normalize_key` is already in scope.
+- **GOTCHA**:
+  - The `conn.row_factory = sqlite3.Row` contract is assumed here (it's the project convention, set in `open_db` and in the test fixture). Index `row["id"]`, not `row[0]`, to stay consistent with the rest of `db.py`.
+  - `RETURNING` only yields rows for *newly inserted* rows. On conflict it yields zero rows → `fetchone()` returns `None` → we enter the fallback SELECT.
+  - Keep the fallback SELECT *outside* `with conn:`. The winner's transaction must already be committed by the time we query; running the SELECT inside our own txn is fine but not required, and pulling it out keeps the commit boundary minimal.
+  - Do NOT keep `cur.lastrowid` — it's unreliable on the conflict path.
+- **VALIDATE**: `pytest tests/test_db.py::TestBrandModelKeyMigrationV7::test_v7_register_product_matches_whitespace_variants -v` must still pass (preserves the (int, bool) contract and first-writer-wins). Then `pytest -q` (full suite) must stay at 296 passed.
+
+### Task 2: Add concurrency test class
+
+- **ACTION**: Add `TestRegisterProductConcurrency` to `tests/test_db.py` at the end of the file, after `TestFindProductByEanBrandGuardV7`. Two tests: (a) N concurrent threads registering the same normalized (brand, model) — exactly one gets `is_new=True`, the rest get `is_new=False` and the same `product_id`, none raise. (b) Concurrent writers with different display literals — the stored `brand` / `model` match whichever thread won (no corruption), and all threads see the same `product_id`.
+- **IMPLEMENT**:
+  ```python
+  # ─── register_product concurrency ────────────────────────────────
+
+
+  class TestRegisterProductConcurrency:
+      """`register_product` must be race-safe: concurrent writers for
+      the same normalized (brand, model) must all return the same
+      product_id, with exactly one is_new=True and no IntegrityError
+      escaping. Regression guard against the pre-UPSERT TOCTOU window.
+      """
+
+      def _run_workers(self, db_path, variants):
+          import threading
+
+          results: list[tuple[int, bool] | BaseException] = [None] * len(variants)
+
+          def worker(i, brand, model):
+              c = sqlite3.connect(str(db_path), timeout=5.0)
+              c.row_factory = sqlite3.Row
+              c.execute("PRAGMA foreign_keys = ON")
+              try:
+                  from amz_scout.db import register_product
+                  results[i] = register_product(c, "Router", brand, model)
+              except BaseException as exc:
+                  results[i] = exc
+              finally:
+                  c.close()
+
+          threads = [
+              threading.Thread(target=worker, args=(i, b, m))
+              for i, (b, m) in enumerate(variants)
+          ]
+          for t in threads:
+              t.start()
+          for t in threads:
+              t.join()
+          return results
+
+      def test_concurrent_same_key_no_integrity_error(self, tmp_path):
+          """N workers all register the same normalized (brand, model).
+          Exactly one sees is_new=True; all share the same product_id;
+          no IntegrityError leaks out.
+          """
+          import amz_scout.db as db_mod
+
+          db_path = tmp_path / "concurrency.db"
+          c0 = sqlite3.connect(str(db_path))
+          c0.execute("PRAGMA foreign_keys = ON")
+          init_schema(c0)
+          c0.close()
+          db_mod._schema_initialized.discard(str(db_path))
+
+          variants = [("TP-Link", "Archer BE400")] * 8
+          results = self._run_workers(db_path, variants)
+
+          for r in results:
+              assert not isinstance(r, BaseException), (
+                  f"worker raised: {r!r}"
+              )
+          ids = {r[0] for r in results}
+          new_flags = [r[1] for r in results]
+          assert len(ids) == 1, f"expected all workers to agree on id, got {ids}"
+          assert new_flags.count(True) == 1, (
+              f"expected exactly one is_new=True, got {new_flags}"
+          )
+          assert new_flags.count(False) == 7
+
+      def test_concurrent_variant_literals_display_is_first_writer(self, tmp_path):
+          """Concurrent writers pass different casing/whitespace variants
+          of the same normalized key. Regardless of which thread wins,
+          the stored display literal is one of the inputs (no corruption)
+          and all threads observe the same product_id.
+          """
+          import amz_scout.db as db_mod
+
+          db_path = tmp_path / "concurrency_variants.db"
+          c0 = sqlite3.connect(str(db_path))
+          c0.execute("PRAGMA foreign_keys = ON")
+          init_schema(c0)
+          c0.close()
+          db_mod._schema_initialized.discard(str(db_path))
+
+          variants = [
+              ("TP-Link", "Archer BE400"),
+              ("tp-link", "archer be400"),
+              ("  TP-LINK  ", "Archer  BE400"),
+              ("Tp-Link", "archer\tbe400"),
+          ]
+          results = self._run_workers(db_path, variants)
+          for r in results:
+              assert not isinstance(r, BaseException), (
+                  f"worker raised: {r!r}"
+              )
+          ids = {r[0] for r in results}
+          assert len(ids) == 1, f"expected single canonical id, got {ids}"
+
+          c = sqlite3.connect(str(db_path))
+          c.row_factory = sqlite3.Row
+          row = c.execute(
+              "SELECT brand, model, brand_key, model_key FROM products"
+          ).fetchone()
+          c.close()
+          # Display literal is ONE of the raced inputs, not a merged
+          # string. Keys are canonical.
+          assert (row["brand"], row["model"]) in variants
+          assert row["brand_key"] == "tp-link"
+          assert row["model_key"] == "archer be400"
+  ```
+- **MIRROR**: `TEST_STRUCTURE` + the new `TEST_CONCURRENCY` skeleton above. For the schema-init pattern, follow the `db_mod._schema_initialized.discard(...)` trick already used by `test_v7_migrates_v6_db_and_merges_duplicates` at `tests/test_db.py:674`.
+- **IMPORTS**: All inside functions (matches existing test style — see `TestFindProductByEanBrandGuardV7` at `tests/test_db.py:878+`).
+- **GOTCHA**:
+  - Use `tmp_path` (file-backed), not `conn` (`:memory:`). SQLite `:memory:` DBs are **connection-local**; multiple connections would each get a fresh empty DB and the test would be a no-op.
+  - Pass `timeout=5.0` on every threaded connection. SQLite's default is 0s → under contention workers would raise `OperationalError: database is locked` and look like a test flake.
+  - Always set `PRAGMA foreign_keys = ON` per connection — it's connection-scoped.
+  - Clear `db_mod._schema_initialized` for the path so `init_schema` inside workers (if called) will run; though in this test the bootstrap connection already primed the schema, workers do not call `init_schema` and therefore don't need this. Keep the `.discard` call as a defensive no-op for parity with the existing migration test.
+- **VALIDATE**: `pytest tests/test_db.py::TestRegisterProductConcurrency -v` — both tests pass under repeated runs (try ~10 iterations locally: `for i in $(seq 10); do pytest tests/test_db.py::TestRegisterProductConcurrency -q || break; done`). Full suite must land at 298 passed.
+
+### Task 3: Verify existing tests still lock in the contract
+
+- **ACTION**: Run the v7 test classes without code changes — they cover the single-threaded case of the new upsert path.
+- **IMPLEMENT**: No code changes. Just verify.
+- **MIRROR**: N/A.
+- **IMPORTS**: N/A.
+- **GOTCHA**: If `test_v7_register_product_preserves_display` starts to fail, the RETURNING-plus-fallback rewrite accidentally overwrites the display literal on hit. Revisit Task 1.
+- **VALIDATE**: `pytest tests/test_db.py::TestBrandModelKeyMigrationV7 tests/test_db.py::TestQuerySideNormalizationV7 -v` → 13 passed.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+| Test | Input | Expected Output | Edge Case? |
+|---|---|---|---|
+| `test_v7_register_product_matches_whitespace_variants` (existing) | Three whitespace/case variants | Same `pid`; new flags `[True, False, False]` | No — happy path |
+| `test_v7_register_product_preserves_display` (existing) | Second call with lowercase | Stored literal stays first writer's | No — display contract |
+| `test_concurrent_same_key_no_integrity_error` (new) | 8 threads, identical (brand, model) | 1× `is_new=True`, 7× `is_new=False`, one shared id, zero exceptions | **Yes — TOCTOU race** |
+| `test_concurrent_variant_literals_display_is_first_writer` (new) | 4 threads, literal-variant (brand, model) | Single canonical id; stored display ∈ input set; keys normalized | **Yes — race + display preservation** |
+
+### Edge Cases Checklist
+
+- [x] Concurrent access — covered by Task 2
+- [x] First-writer-wins display literal under race — covered
+- [x] Same-id convergence across threads — covered
+- [ ] Empty / very long brand — intentionally OUT OF SCOPE; tracked under pr-test-analyzer's nice-to-have #5 (`test_register_product_empty_brand_model`). Not a regression risk for this fix.
+- [ ] Cross-process race (multiple OS processes) — skipped; `threading` within one process exercises the same SQLite write-lock that cross-process workers would hit. Adding multiprocessing fanout has no additional signal and doubles flake risk.
+
+---
+
+## Validation Commands
+
+### Static Analysis
+
+No TypeScript / type-checker in this repo. `ruff` is the project linter.
+
+```bash
+ruff check src/amz_scout/db.py tests/test_db.py
+```
+
+EXPECT: zero errors.
+
+### Unit Tests (targeted)
+
+```bash
+pytest tests/test_db.py::TestRegisterProductConcurrency -v
+pytest tests/test_db.py::TestBrandModelKeyMigrationV7 tests/test_db.py::TestQuerySideNormalizationV7 -v
+```
+
+EXPECT: both groups pass.
+
+### Full Test Suite
+
+```bash
+pytest -q
+```
+
+EXPECT: 298 passed, 8 skipped (was 296 passed pre-change, +2 from the new concurrency class).
+
+### Race-Repetition (flake check)
+
+```bash
+for i in $(seq 1 10); do
+  pytest tests/test_db.py::TestRegisterProductConcurrency -q || { echo "flake at iteration $i"; break; }
+done
+```
+
+EXPECT: 10 consecutive green runs. If any iteration fails, the upsert is not truly atomic — re-examine Task 1.
+
+### Manual Validation
+
+- [ ] Read the rewritten `register_product` aloud. It should be a single UPSERT + conditional SELECT — no `lastrowid`, no bare SELECT-before-INSERT.
+- [ ] `grep -n "SELECT id FROM products" src/amz_scout/db.py` — expect one hit inside `register_product` (the fallback) and no other callers that could sneak in a literal comparison.
+- [ ] `grep -n "cur.lastrowid" src/amz_scout/db.py` — `register_product` must no longer appear.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `register_product` returns `(existing_id, False)` on conflict with zero exceptions.
+- [ ] Concurrency tests pass 10/10 consecutive iterations.
+- [ ] Existing display-literal preservation tests still pass.
+- [ ] Full test suite at 298 passed.
+- [ ] `ruff check` clean.
+
+## Completion Checklist
+
+- [ ] Matches `register_asin` UPSERT style.
+- [ ] `_normalize_key` still invoked before binding keys (no duplicate normalization).
+- [ ] `(int, bool)` return contract unchanged.
+- [ ] Display literal preserved on hit (not overwritten).
+- [ ] No new dependencies introduced.
+- [ ] No changes outside `db.py` / `test_db.py`.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Host SQLite older than 3.35 (no RETURNING) | Low | High — build breaks at runtime | Project pins Python ≥3.12; stdlib sqlite3 bundles ≥3.40. Add a startup assert only if a deploy target without a bundled sqlite appears. |
+| Thread-based test flakes on CI with low scheduling variance | Low | Medium | Use file-backed DB + `timeout=5.0` + 8 workers (enough to force contention). Run repetition loop locally once; if it ever flakes in CI, bump thread count. |
+| `conn.row_factory = sqlite3.Row` assumption breaks if a caller passes a bare connection | Low | Low | All entry points (`open_db`, test `conn` fixture, webapp bootstrap) already set `row_factory`. Non-conforming callers are an independent bug. |
+| Fallback SELECT races with another concurrent DELETE | Very low | Low | `register_product` never runs concurrently with delete paths in this project; SQLite's write-lock serializes them anyway. |
+
+## Notes
+
+- The fix is deliberately minimal. Any broader concurrency hardening (connection pool, WAL tuning, cross-process test coverage) belongs in a separate, larger effort — not this plan.
+- If `INSERT ... RETURNING` returns zero rows but the subsequent SELECT also returns zero rows, that signals either schema corruption or an unexpected third party (e.g. a DELETE) ran between the two statements. The fallback will raise `TypeError: 'NoneType' object is not subscriptable`; this is acceptable — the contract of `register_product` assumes a stable schema, and surfacing a loud failure is better than silently returning a fake id. No defensive handling required.
+- A follow-up to unify `_find_product_by_ean` normalization with `_normalize_key` (M1 from the local review / partial overlap with issue #12) is tracked separately and is NOT part of this plan.

--- a/.claude/PRPs/reports/register-product-toctou-fix-report.md
+++ b/.claude/PRPs/reports/register-product-toctou-fix-report.md
@@ -1,0 +1,102 @@
+# Implementation Report: `register_product` TOCTOU race fix
+
+## Summary
+
+Collapsed the racy `SELECT → with conn: INSERT` pattern in
+`register_product` (src/amz_scout/db.py) into a single atomic
+`INSERT ... ON CONFLICT(brand_key, model_key) DO NOTHING RETURNING id`
+statement, with a fallback `SELECT` only on the conflict path. This
+closes the TOCTOU window where concurrent webapp requests could both
+pass the existence check and race on the INSERT, surfacing
+`sqlite3.IntegrityError` instead of the documented `(existing_id, False)`
+return contract. Added `TestRegisterProductConcurrency` with two
+threading-based tests pinning the race-safe behavior and the
+first-writer-wins display-literal contract. Full suite: 298 passed, 8
+skipped; concurrency class stable across 10 repetitions.
+
+## Assessment vs Reality
+
+| Metric | Predicted (Plan) | Actual |
+|---|---|---|
+| Complexity | Small | Small |
+| Confidence | N/A (plan did not state) | High |
+| Files Changed | 2 | 2 |
+| Tests Added | 2 | 2 |
+| Full Suite | 298 passed | 298 passed, 8 skipped |
+
+## Tasks Completed
+
+| # | Task | Status | Notes |
+|---|---|---|---|
+| 1 | Rewrite `register_product` to single-statement UPSERT + fallback SELECT | Complete | Matches `register_asin` UPSERT style exactly |
+| 2 | Add `TestRegisterProductConcurrency` class (2 tests) | Complete | Minor cleanup: narrowed result types via `isinstance(r, tuple)` to silence Pyright — see Deviations |
+| 3 | Verify existing v7 contract tests still pass | Complete | `TestBrandModelKeyMigrationV7` + `TestQuerySideNormalizationV7` → 10 passed (plan estimated 13; the two classes actually contain 10 tests total) |
+
+## Validation Results
+
+| Level | Status | Notes |
+|---|---|---|
+| Static Analysis (ruff) | Pass | `ruff check src/amz_scout/db.py tests/test_db.py` → clean |
+| Unit Tests (concurrency) | Pass | `TestRegisterProductConcurrency` → 2/2 |
+| Unit Tests (v7 contract) | Pass | `TestBrandModelKeyMigrationV7` + `TestQuerySideNormalizationV7` → 10/10 |
+| Full Suite | Pass | `pytest -q` → 298 passed, 8 skipped |
+| Flake Check | Pass | 10/10 consecutive runs of `TestRegisterProductConcurrency` |
+| Build | N/A | Pure-Python project, no separate build step |
+| Manual Validation | Pass | `cur.lastrowid` no longer in `db.py`; `SELECT id FROM products` appears only in the expected fallback + the pre-existing `find_product_exact` |
+
+## Files Changed
+
+| File | Action | Lines |
+|---|---|---|
+| `src/amz_scout/db.py` | UPDATED | +12 / −10 |
+| `tests/test_db.py` | UPDATED | +106 / 0 |
+
+Total: 2 files, +118 / −10.
+
+## Deviations from Plan
+
+1. **Type-narrowing rewrite in the concurrency helper.** Plan's test
+   skeleton initialized `results: list[tuple[int, bool] | BaseException]`
+   with `[None] * len(variants)`, which triggered Pyright
+   `reportAssignmentType` (list invariance: `list[None]` is not
+   assignable) plus `reportIndexIssue` on `r[0]` / `r[1]` because
+   `assert not isinstance(r, BaseException)` does not narrow across
+   iteration. **What changed**: expanded the type to
+   `list[tuple[int, bool] | BaseException | None]` and replaced the
+   `not isinstance(..., BaseException)` assertion with
+   `assert isinstance(r, tuple)` + a `[r for r in results if isinstance(r, tuple)]`
+   comprehension that Pyright *does* narrow. **Why**: the plan's code was
+   functionally correct but produced editor/LSP diagnostic noise;
+   project has no Pyright config so this was not a hard gate, but the
+   clean narrowing is both type-safe and more readable. No behavioral
+   change — both tests still assert no exceptions escape and all
+   workers converge on one id.
+
+## Issues Encountered
+
+None beyond the Pyright narrowing note above. The atomic UPSERT worked
+first try; both concurrency tests passed on the first run and remained
+stable across 10 repetitions.
+
+## Tests Written
+
+| Test File | Tests | Coverage |
+|---|---|---|
+| `tests/test_db.py` | `test_concurrent_same_key_no_integrity_error` | 8 threads, identical (brand, model); verifies exactly one `is_new=True`, 7× `is_new=False`, single shared `product_id`, zero exceptions |
+| `tests/test_db.py` | `test_concurrent_variant_literals_display_is_first_writer` | 4 threads, different case/whitespace variants; verifies single canonical id, stored display literal ∈ input set, `brand_key` / `model_key` normalized |
+
+## Acceptance Criteria
+
+- [x] `register_product` returns `(existing_id, False)` on conflict with zero exceptions (verified by `test_concurrent_same_key_no_integrity_error`).
+- [x] Concurrency tests pass 10/10 consecutive iterations.
+- [x] Existing display-literal preservation tests still pass (`test_v7_register_product_preserves_display`).
+- [x] Full test suite at 298 passed.
+- [x] `ruff check` clean.
+
+## Next Steps
+
+- [ ] Code review via `/code-review` (optional — changes are small and
+      mirror an existing pattern).
+- [ ] Create PR via `/prp-pr` — follow-up to PR #15 code-review finding.
+- [ ] Monitor webapp error rates post-deploy; pre-fix the race would
+      surface as sporadic 500s during concurrent Keepa-fetch bursts.

--- a/.claude/PRPs/reviews/local-review-register-product-toctou.md
+++ b/.claude/PRPs/reviews/local-review-register-product-toctou.md
@@ -1,0 +1,73 @@
+# Local Code Review: register_product TOCTOU fix
+
+**Reviewed**: 2026-04-20
+**Branch**: `fix/register-product-toctou` → `main`
+**Decision**: APPROVE (with optional L1 note)
+
+## Summary
+
+Two-file diff (`src/amz_scout/db.py` +12/−10, `tests/test_db.py` +106/−0).
+Collapses a racy SELECT→INSERT in `register_product` into a single
+atomic `INSERT ... ON CONFLICT DO NOTHING RETURNING id` with a fallback
+SELECT; adds two threading-based concurrency tests. Mirrors the
+pre-existing `register_asin` UPSERT style exactly. Zero CRITICAL / HIGH
+findings; validation clean; 10/10 flake-repetition stable.
+
+## Findings
+
+### CRITICAL
+None.
+
+### HIGH
+None.
+
+### MEDIUM
+
+**M1. Fallback SELECT without None-guard — documented trade-off, not a bug**
+- Location: `src/amz_scout/db.py:1626-1630`
+- The fallback path calls `existing["id"]` without checking `existing is None`. Theoretically, a concurrent DELETE between the UPSERT conflict and the fallback SELECT would surface `TypeError: 'NoneType' object is not subscriptable`.
+- Plan explicitly addresses this: "the contract of `register_product` assumes a stable schema, and surfacing a loud failure is better than silently returning a fake id. No defensive handling required." `register_product` never runs concurrently with a delete path in this codebase; SQLite's write-lock further serializes them.
+- Action: None. Intentional design per plan.
+
+### LOW
+
+**L1. Test DB does not enable WAL — preemptive hardening**
+- Location: `tests/test_db.py:982, 1017`
+- The bootstrap connection `c0` sets `PRAGMA foreign_keys = ON` but not `PRAGMA journal_mode = WAL`. The `conftest.py :memory:` fixture does enable WAL. With the default rollback journal, 8 concurrent writers lean harder on `timeout=5.0` busy-wait to avoid "database is locked".
+- Evidence of stability: 10/10 iterations green locally. But if CI hosts are slow or worker count rises, this is the first place to wobble.
+- Suggested fix: `c0.execute("PRAGMA journal_mode = WAL")` in each bootstrap. One-line preemptive change.
+- Action: Optional, non-blocking.
+
+**L2. Test file now exceeds 800 lines (1054, up from 948)**
+- Location: `tests/test_db.py`
+- Pre-existing condition; this PR adds 106 lines. Rules suggest <800. Organization by feature-class remains clean.
+- Action: Out of scope for this PR. Consider splitting to `tests/db/test_*.py` in a future refactor.
+
+**L3. Worker catches `BaseException`**
+- Location: `tests/test_db.py:968`
+- `except BaseException as exc` would swallow `KeyboardInterrupt` / `SystemExit`. In a non-daemon test thread this is contained but slightly heavy.
+- Suggested fix: narrow to `Exception`.
+- Action: Optional style nit.
+
+## Validation Results
+
+| Check | Result |
+|---|---|
+| Ruff | Pass |
+| Pytest — `tests/test_db.py` | Pass (47/47) |
+| Pytest — full suite (prior run) | Pass (298 passed, 8 skipped) |
+| Flake check (10× `TestRegisterProductConcurrency`) | Pass |
+| Manual grep — `cur.lastrowid` in `db.py` | Cleared |
+| Manual grep — `SELECT id FROM products` | 2 hits: one fallback in `register_product`, one in unrelated `find_product_exact` |
+
+## Files Reviewed
+
+- `src/amz_scout/db.py` — Modified (register_product rewrite)
+- `tests/test_db.py` — Modified (new TestRegisterProductConcurrency class)
+
+## Notes
+
+- Atomic UPSERT is correct: RETURNING yields one row on insert, zero on conflict; `.fetchone()` inside `with conn:` is consumed before commit.
+- Fallback SELECT is outside `with conn:` — winner's transaction is guaranteed committed before the read.
+- Pattern compliance: mirrors `register_asin` at `db.py:1640-1648` exactly.
+- Immutability: `(int, bool)` tuple return preserved; no in-place mutation added.

--- a/src/amz_scout/db.py
+++ b/src/amz_scout/db.py
@@ -1612,20 +1612,22 @@ def register_product(
     """
     brand_key = _normalize_key(brand)
     model_key = _normalize_key(model)
-    row = conn.execute(
+    with conn:
+        row = conn.execute(
+            "INSERT INTO products "
+            "(category, brand, model, brand_key, model_key, search_keywords) "
+            "VALUES (?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(brand_key, model_key) DO NOTHING "
+            "RETURNING id",
+            (category, brand, model, brand_key, model_key, search_keywords),
+        ).fetchone()
+    if row is not None:
+        return row["id"], True
+    existing = conn.execute(
         "SELECT id FROM products WHERE brand_key = ? AND model_key = ?",
         (brand_key, model_key),
     ).fetchone()
-    if row:
-        return row["id"], False
-    with conn:
-        cur = conn.execute(
-            "INSERT INTO products "
-            "(category, brand, model, brand_key, model_key, search_keywords) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (category, brand, model, brand_key, model_key, search_keywords),
-        )
-    return cur.lastrowid, True  # type: ignore[return-value]
+    return existing["id"], False
 
 
 def register_asin(

--- a/src/amz_scout/db.py
+++ b/src/amz_scout/db.py
@@ -1627,6 +1627,11 @@ def register_product(
         "SELECT id FROM products WHERE brand_key = ? AND model_key = ?",
         (brand_key, model_key),
     ).fetchone()
+    if existing is None:
+        raise RuntimeError(
+            "register_product conflict fallback found no row for "
+            f"brand_key={brand_key!r}, model_key={model_key!r}"
+        )
     return existing["id"], False
 
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -962,6 +962,9 @@ class TestRegisterProductConcurrency:
         import threading
 
         results: list[tuple[int, bool] | Exception | None] = [None] * len(variants)
+        # Barrier forces all workers into the write-path simultaneously
+        # so contention is deterministic rather than order-of-start.
+        barrier = threading.Barrier(len(variants))
 
         def worker(i, brand, model):
             c = sqlite3.connect(str(db_path), timeout=5.0)
@@ -969,6 +972,7 @@ class TestRegisterProductConcurrency:
             c.execute("PRAGMA foreign_keys = ON")
             try:
                 from amz_scout.db import register_product
+                barrier.wait(timeout=5.0)
                 results[i] = register_product(c, "Router", brand, model)
             except Exception as exc:
                 results[i] = exc

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -946,3 +946,109 @@ class TestFindProductByEanBrandGuardV7:
 
         raw = {"eanList": ["1234567890123"], "brand": ""}
         assert _find_product_by_ean(conn, "B0NEW000001", raw) == pid
+
+
+# ─── register_product concurrency ────────────────────────────────
+
+
+class TestRegisterProductConcurrency:
+    """`register_product` must be race-safe: concurrent writers for
+    the same normalized (brand, model) must all return the same
+    product_id, with exactly one is_new=True and no IntegrityError
+    escaping. Regression guard against the pre-UPSERT TOCTOU window.
+    """
+
+    def _run_workers(self, db_path, variants):
+        import threading
+
+        results: list[tuple[int, bool] | BaseException | None] = [None] * len(variants)
+
+        def worker(i, brand, model):
+            c = sqlite3.connect(str(db_path), timeout=5.0)
+            c.row_factory = sqlite3.Row
+            c.execute("PRAGMA foreign_keys = ON")
+            try:
+                from amz_scout.db import register_product
+                results[i] = register_product(c, "Router", brand, model)
+            except BaseException as exc:
+                results[i] = exc
+            finally:
+                c.close()
+
+        threads = [
+            threading.Thread(target=worker, args=(i, b, m))
+            for i, (b, m) in enumerate(variants)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        return results
+
+    def test_concurrent_same_key_no_integrity_error(self, tmp_path):
+        """N workers all register the same normalized (brand, model).
+        Exactly one sees is_new=True; all share the same product_id;
+        no IntegrityError leaks out.
+        """
+        import amz_scout.db as db_mod
+
+        db_path = tmp_path / "concurrency.db"
+        c0 = sqlite3.connect(str(db_path))
+        c0.execute("PRAGMA foreign_keys = ON")
+        init_schema(c0)
+        c0.close()
+        db_mod._schema_initialized.discard(str(db_path))
+
+        variants = [("TP-Link", "Archer BE400")] * 8
+        results = self._run_workers(db_path, variants)
+
+        for r in results:
+            assert isinstance(r, tuple), f"worker raised or missed: {r!r}"
+        tuple_results = [r for r in results if isinstance(r, tuple)]
+        ids = {r[0] for r in tuple_results}
+        new_flags = [r[1] for r in tuple_results]
+        assert len(ids) == 1, f"expected all workers to agree on id, got {ids}"
+        assert new_flags.count(True) == 1, (
+            f"expected exactly one is_new=True, got {new_flags}"
+        )
+        assert new_flags.count(False) == 7
+
+    def test_concurrent_variant_literals_display_is_first_writer(self, tmp_path):
+        """Concurrent writers pass different casing/whitespace variants
+        of the same normalized key. Regardless of which thread wins,
+        the stored display literal is one of the inputs (no corruption)
+        and all threads observe the same product_id.
+        """
+        import amz_scout.db as db_mod
+
+        db_path = tmp_path / "concurrency_variants.db"
+        c0 = sqlite3.connect(str(db_path))
+        c0.execute("PRAGMA foreign_keys = ON")
+        init_schema(c0)
+        c0.close()
+        db_mod._schema_initialized.discard(str(db_path))
+
+        variants = [
+            ("TP-Link", "Archer BE400"),
+            ("tp-link", "archer be400"),
+            ("  TP-LINK  ", "Archer  BE400"),
+            ("Tp-Link", "archer\tbe400"),
+        ]
+        results = self._run_workers(db_path, variants)
+        for r in results:
+            assert isinstance(r, tuple), f"worker raised or missed: {r!r}"
+        tuple_results = [r for r in results if isinstance(r, tuple)]
+        ids = {r[0] for r in tuple_results}
+        assert len(ids) == 1, f"expected single canonical id, got {ids}"
+
+        c = sqlite3.connect(str(db_path))
+        c.row_factory = sqlite3.Row
+        row = c.execute(
+            "SELECT brand, model, brand_key, model_key FROM products"
+        ).fetchone()
+        c.close()
+        # Display literal is ONE of the raced inputs, not a merged
+        # string. Keys are canonical.
+        assert (row["brand"], row["model"]) in variants
+        assert row["brand_key"] == "tp-link"
+        assert row["model_key"] == "archer be400"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -961,7 +961,7 @@ class TestRegisterProductConcurrency:
     def _run_workers(self, db_path, variants):
         import threading
 
-        results: list[tuple[int, bool] | BaseException | None] = [None] * len(variants)
+        results: list[tuple[int, bool] | Exception | None] = [None] * len(variants)
 
         def worker(i, brand, model):
             c = sqlite3.connect(str(db_path), timeout=5.0)
@@ -970,7 +970,7 @@ class TestRegisterProductConcurrency:
             try:
                 from amz_scout.db import register_product
                 results[i] = register_product(c, "Router", brand, model)
-            except BaseException as exc:
+            except Exception as exc:
                 results[i] = exc
             finally:
                 c.close()
@@ -994,6 +994,7 @@ class TestRegisterProductConcurrency:
 
         db_path = tmp_path / "concurrency.db"
         c0 = sqlite3.connect(str(db_path))
+        c0.execute("PRAGMA journal_mode = WAL")
         c0.execute("PRAGMA foreign_keys = ON")
         init_schema(c0)
         c0.close()
@@ -1023,6 +1024,7 @@ class TestRegisterProductConcurrency:
 
         db_path = tmp_path / "concurrency_variants.db"
         c0 = sqlite3.connect(str(db_path))
+        c0.execute("PRAGMA journal_mode = WAL")
         c0.execute("PRAGMA foreign_keys = ON")
         init_schema(c0)
         c0.close()


### PR DESCRIPTION
## Summary

Follow-up to PR #15 code-review finding. Collapses the racy `SELECT → with conn: INSERT` in `register_product` into a single atomic `INSERT ... ON CONFLICT(brand_key, model_key) DO NOTHING RETURNING id` with a fallback `SELECT` only on the conflict path. Closes the TOCTOU window where concurrent webapp writers for the same normalized `(brand, model)` could both pass the existence check and collide on INSERT, surfacing `sqlite3.IntegrityError` instead of the documented `(existing_id, False)` return.

## Changes

- `src/amz_scout/db.py:1595-1630` — rewrite `register_product` as single-statement UPSERT. Mirrors the existing `register_asin` UPSERT style (`db.py:1640-1648`). `(int, bool)` return contract, docstring, and display-literal preservation semantics unchanged.
- `tests/test_db.py` — add `TestRegisterProductConcurrency` with two threading-based tests:
  - `test_concurrent_same_key_no_integrity_error` — 8 threads, identical key, exactly one `is_new=True` and zero exceptions.
  - `test_concurrent_variant_literals_display_is_first_writer` — 4 threads with case/whitespace variants, single canonical id, stored display literal ∈ input set, keys normalized.

## Files Changed

| File | Change |
|---|---|
| `src/amz_scout/db.py` | Modified (+12 / −10) |
| `tests/test_db.py` | Modified (+106 / 0) |
| `.claude/PRPs/plans/completed/register-product-toctou-fix.plan.md` | Added (archived plan) |
| `.claude/PRPs/reports/register-product-toctou-fix-report.md` | Added |
| `.claude/PRPs/reviews/local-review-register-product-toctou.md` | Added |

## Testing

- [x] `ruff check src/amz_scout/db.py tests/test_db.py` — clean
- [x] `pytest tests/test_db.py::TestRegisterProductConcurrency -v` — 2/2 passed
- [x] `pytest tests/test_db.py::TestBrandModelKeyMigrationV7 tests/test_db.py::TestQuerySideNormalizationV7 -v` — 10/10 passed (v7 contract preserved)
- [x] `pytest -q` — 298 passed, 8 skipped
- [x] Flake check: `TestRegisterProductConcurrency` stable across 10 consecutive iterations

## Related

- Follow-up to code-review finding on PR #15 (refs #15)
- Plan: `.claude/PRPs/plans/completed/register-product-toctou-fix.plan.md`
- Report: `.claude/PRPs/reports/register-product-toctou-fix-report.md`
- Local review: `.claude/PRPs/reviews/local-review-register-product-toctou.md`