### PR TITLE
fix: prevent transient Keepa blips from marking active ASIN not_listed

### DIFF
--- a/.claude/PRPs/plans/completed/fix-transient-failure-permanent-dead-listing.plan.md
+++ b/.claude/PRPs/plans/completed/fix-transient-failure-permanent-dead-listing.plan.md
@@ -1,0 +1,844 @@
+# Plan: Fix transient-failure permanent dead-listing (closes #11)
+
+## Summary
+
+A single transient Keepa response (rate-limit, network blip, partial JSON) currently
+sets `product_asins.status = 'not_listed'` permanently, blacklisting a live ASIN
+with no automated recovery. This plan replaces the one-shot "empty title + no csv"
+check with a two-gate decision: (1) only genuine Keepa "no data" responses
+(`fetch_error == ""`) are eligible, and (2) `not_listed` requires N consecutive
+eligible observations tracked by a new `not_listed_strikes` counter column.
+Successful fetches clear the counter.
+
+## User Story
+
+As an amz-scout operator running recurring `ensure_keepa_data` jobs,
+I want a single Keepa blip not to permanently blacklist a live ASIN,
+so that I can trust the `not_listed` gate to reflect real Amazon delistings
+and not transient API failures.
+
+## Problem → Solution
+
+**Current**: `api.py:922` checks `not title and not has_csv` after every fetch.
+Any transient Keepa blip (rate-limit, network, partial response) satisfies that
+condition and permanently flips status to `not_listed`. The only recovery is a
+manual `update_asin_status()` call, which has zero test coverage.
+
+**Target**:
+1. `fetch_error != ""` → log WARNING, do nothing to status / counter.
+2. `fetch_error == ""` AND `title` empty AND `has_csv` false → increment
+   `not_listed_strikes`. Flip to `not_listed` only when strikes ≥ threshold (3).
+3. Any fetch that returns a title or csv → reset `not_listed_strikes` to 0.
+4. `not_listed → active` recovery path gets explicit test coverage.
+
+## Metadata
+
+- **Complexity**: Medium
+- **Source PRD**: N/A (direct fix for GitHub issue #11)
+- **PRD Phase**: N/A
+- **Estimated Files**: 4 modified, 0 created
+  - `src/amz_scout/db.py` — add v8 migration + strike helpers
+  - `src/amz_scout/api.py` — rewrite post-fetch validation + replace `_try_mark_not_listed`
+  - `tests/test_api.py` — add post-validation strike tests + recovery coverage
+  - `docs/DEVELOPER.md` — update ASIN Status Semantics section + migration table
+
+---
+
+## UX Design
+
+### Before
+
+```
+┌────────────────────────────────────────────────┐
+│ User runs ensure_keepa_data(...) at 09:00      │
+│   Keepa returns 429 for B0F2MR53D6             │
+│   api.py marks (B0F2MR53D6, UK) = not_listed   │
+│                                                │
+│ User runs query_trends(..."UK") at 09:05       │
+│   ValueError: "ASIN observed delisted on       │
+│   Amazon. Run discover_asin() or               │
+│   update_asin_status() if misclassified."      │
+│                                                │
+│ Product is actually live.                      │
+│ Recovery requires manual SQL knowledge.        │
+└────────────────────────────────────────────────┘
+```
+
+### After
+
+```
+┌────────────────────────────────────────────────┐
+│ User runs ensure_keepa_data(...) at 09:00      │
+│   Keepa returns 429 for B0F2MR53D6             │
+│   fetch_error="rate_limited" → WARNING only.   │
+│   status stays 'active', strikes stays 0.      │
+│                                                │
+│ User runs query_trends(..."UK") at 09:05       │
+│   Cache hit, returns last-known trend data.    │
+│                                                │
+│ (Hypothetical) 3 consecutive fetches return    │
+│ truly empty bodies → flip to 'not_listed'.     │
+│ A single successful fetch in between resets    │
+│ strikes to 0.                                  │
+└────────────────────────────────────────────────┘
+```
+
+### Interaction Changes
+
+| Touchpoint | Before | After | Notes |
+|---|---|---|---|
+| `ensure_keepa_data` warnings | Single transient blip → "ASIN has no data" + status flipped | Transient blip → "Transient Keepa failure (rate_limited) for …; status unchanged" + status preserved | Distinguishes causes in user-facing text |
+| `query_*` failure after one blip | ValueError forever until manual recovery | No ValueError — status still `active` | The primary bug fix |
+| Strike accumulation (new) | N/A | "Empty Keepa response for … (strike 2/3); will mark not_listed after 3 consecutive observations" | Makes gradual dead-listing observable |
+| Recovery from `not_listed` | Manual SQL | Still manual via `update_asin_status(..., status='active')`, now with test coverage | Issue explicitly flags untested recovery path |
+
+---
+
+## Mandatory Reading
+
+| Priority | File | Lines | Why |
+|---|---|---|---|
+| P0 | `src/amz_scout/api.py` | 398-420, 882-948 | Exact functions to modify: `_try_mark_not_listed` + `ensure_keepa_data` post-fetch validation. |
+| P0 | `src/amz_scout/api.py` | 216-238 | `_check_asin_status_gate` — read side of `not_listed`. Must stay compatible. |
+| P0 | `src/amz_scout/db.py` | 171-420 | Migration machinery (v2-v7). v8 follows `if current < N:` + `INSERT OR IGNORE INTO schema_migrations`. |
+| P0 | `src/amz_scout/db.py` | 729-744 | Current `product_asins` CREATE TABLE — v8 is ADD COLUMN, no rebuild. |
+| P0 | `src/amz_scout/db.py` | 1856-1871 | `update_asin_status` single write entry point. New strike helpers coexist. |
+| P1 | `src/amz_scout/keepa_service.py` | 32-62 | `KeepaProductOutcome` — `price_history.fetch_error` is the signal. |
+| P1 | `src/amz_scout/models.py` | 68-96 | `PriceHistory.fetch_error: str = ""`. Signal already exists. |
+| P1 | `src/amz_scout/scraper/keepa.py` | 131-209 | Where `fetch_error` is populated (rate_limited, invalid_response, api_error, network, unexpected, max_retries_exhausted) + the single "empty" path at line 184. |
+| P1 | `tests/test_api.py` | 916-928, 1030-1102 | Existing `TestEnsureKeepaDataPostValidation` + `TestResolveAsinStatusGate`. New tests go next to them. |
+| P2 | `docs/DEVELOPER.md` | 101-183 | Migrations table + "ASIN Status Semantics" state diagram. Must reflect v8 + threshold. |
+| P2 | `src/amz_scout/db.py` | 344-406 | v6 migration — reference for status-related migration style. |
+
+## External Documentation
+
+| Topic | Source | Key Takeaway |
+|---|---|---|
+| Keepa `products=[]` response | `scraper/keepa.py:182-184` | When Keepa has no record for an ASIN, `resp.json()["products"]` is empty. Our scraper returns `_empty_history(product, site)` with **empty `fetch_error`** — the single signal distinguishing "Keepa knows nothing" from every other empty path. |
+| Keepa HTTP 429 | `scraper/keepa.py:150-167` | Returns `_empty_history(..., fetch_error="rate_limited")` after retries. Always transient. |
+| Keepa non-200 / error JSON | `scraper/keepa.py:177-180` | Returns `_empty_history(..., fetch_error=f"api_error: ...")`. Treat as transient. |
+
+No new external libraries required.
+
+---
+
+## Patterns to Mirror
+
+### NAMING_CONVENTION — private helper shape
+```python
+# SOURCE: src/amz_scout/api.py:398-420
+def _try_mark_not_listed(
+    conn: sqlite3.Connection,
+    asin: str,
+    site: str,
+) -> None:
+    """If this ASIN is in the product registry, mark it as not_listed."""
+    try:
+        from amz_scout.db import update_asin_status
+        row = conn.execute(
+            "SELECT product_id FROM product_asins WHERE asin = ? AND marketplace = ?",
+            (asin, site),
+        ).fetchone()
+        if row:
+            update_asin_status(
+                conn, row["product_id"], site, "not_listed",
+                notes="Keepa returned no title or price data",
+            )
+    except Exception:
+        logger.exception("Failed to mark ASIN %s/%s as not_listed", asin, site)
+```
+Mirror: (1) private underscore name, (2) `try/except Exception` around mutation, (3) `logger.exception(...)` with identifying fields, (4) silent no-op when ASIN isn't in registry.
+
+### SCHEMA_MIGRATION — ADD COLUMN
+```python
+# SOURCE: src/amz_scout/db.py:254-265 (v4 migration)
+if current < 4:
+    cols = [r["name"] for r in conn.execute("PRAGMA table_info(keepa_products)")]
+    if "fetch_mode" not in cols:
+        conn.execute(
+            "ALTER TABLE keepa_products "
+            "ADD COLUMN fetch_mode TEXT NOT NULL DEFAULT 'basic'"
+        )
+    conn.execute(
+        "INSERT OR IGNORE INTO schema_migrations (version, description) "
+        "VALUES (4, 'add fetch_mode to keepa_products')"
+    )
+    logger.info("Migrated schema to version 4")
+```
+v8 follows this exact shape. Lives inside the main `with conn:` txn because it does not touch `PRAGMA foreign_keys`.
+
+### STATUS_WRITE — single entry point
+```python
+# SOURCE: src/amz_scout/db.py:1856-1871
+def update_asin_status(
+    conn: sqlite3.Connection,
+    product_id: int,
+    marketplace: str,
+    status: str,
+    notes: str = "",
+) -> None:
+    with conn:
+        conn.execute(
+            "UPDATE product_asins SET status = ?, notes = ?, last_checked = "
+            "strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), "
+            "updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') "
+            "WHERE product_id = ? AND marketplace = ?",
+            (status, notes, product_id, marketplace),
+        )
+```
+DEVELOPER.md:170-173 calls this "the single write entry point". New strike helpers may update `not_listed_strikes` alone, but any transition that flips `status` to `not_listed` MUST still route through `update_asin_status()`.
+
+### WARNING_ACCUMULATION
+```python
+# SOURCE: src/amz_scout/api.py:904-948
+warnings: list[str] = []
+fetched_outcomes = [o for o in result.outcomes if o.source == "fetched"]
+if fetched_outcomes:
+    # build title_map...
+    for o in fetched_outcomes:
+        title = title_map.get((o.asin, o.site), "")
+        has_csv = o.price_history and (
+            o.price_history.buybox_current is not None
+            or o.price_history.new_current is not None
+        )
+        if not title and not has_csv:
+            warnings.append(...)
+            _try_mark_not_listed(conn, o.asin, o.site)
+
+meta: dict = {...}
+if warnings:
+    meta["warnings"] = warnings
+return _envelope(True, data={"outcomes": outcomes}, **meta)
+```
+Preserve this accumulator shape + `meta["warnings"]` envelope surface.
+
+### TEST_STRUCTURE
+```python
+# SOURCE: tests/test_api.py:1030-1054
+class TestResolveAsinStatusGate:
+    def _setup_db(self, tmp_path):
+        db_path = tmp_path / "status_gate.db"
+        c = sqlite3.connect(str(db_path))
+        c.row_factory = sqlite3.Row
+        init_schema(c)
+        pid, _ = register_product(c, "Router", "TestBrand", "TestModel")
+        register_asin(c, pid, "UK", "B0DEADXXX1", status="not_listed", notes="")
+        register_asin(c, pid, "FR", "B0GOOD0001", status="active", notes="")
+        c.close()
+        return db_path
+
+    def test_raises_on_not_listed_asin_pass_through(self, tmp_path):
+        db_path = self._setup_db(tmp_path)
+        c = sqlite3.connect(str(db_path))
+        c.row_factory = sqlite3.Row
+        with pytest.raises(ValueError, match="not_listed"):
+            _resolve_asin([], "B0DEADXXX1", marketplace="UK", conn=c)
+        c.close()
+```
+Mirror per-test DB setup + `register_product` + `register_asin` + `pytest.raises(..., match=...)` + explicit `c.close()`.
+
+### MONKEYPATCH
+```python
+# SOURCE: tests/test_api.py:1079-1102
+def test_query_envelope_failure_for_not_listed(self, tmp_path, monkeypatch):
+    from pathlib import Path as _Path
+    import amz_scout.api as api_mod
+    def fake_ctx(*args, **kwargs):
+        return _Path(str(db_path)), None
+    monkeypatch.setattr(api_mod, "_resolve_context", fake_ctx)
+    r = query_trends(product="B0DEADXXX1", marketplace="UK", auto_fetch=False)
+```
+For the integration test, monkey-patch `api_mod.get_keepa_data` (imported into api from keepa_service) with a fake `KeepaResult`.
+
+---
+
+## Files to Change
+
+| File | Action | Justification |
+|---|---|---|
+| `src/amz_scout/db.py` | UPDATE | Bump `SCHEMA_VERSION` 7→8. Add v8 migration (ADD COLUMN `not_listed_strikes INTEGER NOT NULL DEFAULT 0`). Add column to baseline `CREATE TABLE product_asins` too. Add `increment_not_listed_strikes()` + `clear_not_listed_strikes()` next to `update_asin_status`. Define `NOT_LISTED_STRIKE_THRESHOLD = 3`. |
+| `src/amz_scout/api.py` | UPDATE | Rewrite the post-fetch loop to branch on `fetch_error`. Replace `_try_mark_not_listed` with `_record_empty_observation` (increments, flips above threshold) and `_record_successful_observation` (resets strikes). Only one caller exists (line 930). |
+| `tests/test_api.py` | UPDATE | Extend `TestEnsureKeepaDataPostValidation` + add `TestEmptyObservationStrikes`, `TestEnsureKeepaDataTransientVsPermanent`, `TestAsinStatusRecovery`. |
+| `docs/DEVELOPER.md` | UPDATE | Append v8 row. Update status state diagram to show strike accumulation + transient path. Document threshold constant. |
+
+## NOT Building
+
+- **NOT** changing `status` enum values. Stays `'active' | 'not_listed'`.
+- **NOT** adding `'suspected_not_listed'` as a user-visible state. Strikes are an internal counter.
+- **NOT** touching `_check_asin_status_gate` / `_resolve_asin` / `load_products_from_db` read paths.
+- **NOT** adding a `not_listed → active` background recovery job. Manual recovery + tests only.
+- **NOT** using `keepa_products.availability_amazon` in this PR — not populated when `products=[]`. Noted as follow-up.
+- **NOT** bundling in async/webapp/auto_fetch_error issues — shipped in PR #18.
+- **NOT** changing the CLI surface or adding user commands.
+
+---
+
+## Step-by-Step Tasks
+
+### Task 1: Schema — add `not_listed_strikes` column + v8 migration
+
+- **ACTION**: Edit `src/amz_scout/db.py`.
+- **IMPLEMENT**:
+  1. Line 105: `SCHEMA_VERSION = 7` → `SCHEMA_VERSION = 8`.
+  2. Add below it:
+     ```python
+     NOT_LISTED_STRIKE_THRESHOLD = 3
+     ```
+  3. In baseline `_SCHEMA_SQL`'s `CREATE TABLE product_asins` (around line 729), add after `last_checked TEXT,`:
+     ```sql
+     not_listed_strikes  INTEGER NOT NULL DEFAULT 0,
+     ```
+     Update the adjacent comment block to explain: "Consecutive-empty counter (transient-failure guard — flip to not_listed only at NOT_LISTED_STRIKE_THRESHOLD)."
+  4. Inside `_migrate()`, after the v6 block and before the `# v7 lives OUTSIDE` comment:
+     ```python
+     if current < 8:
+         cols = [
+             r["name"]
+             for r in conn.execute("PRAGMA table_info(product_asins)")
+         ]
+         if "not_listed_strikes" not in cols:
+             conn.execute(
+                 "ALTER TABLE product_asins "
+                 "ADD COLUMN not_listed_strikes INTEGER NOT NULL DEFAULT 0"
+             )
+         conn.execute(
+             "INSERT OR IGNORE INTO schema_migrations (version, description) "
+             "VALUES (8, 'add not_listed_strikes counter to product_asins')"
+         )
+         logger.info("Migrated schema to version 8")
+     ```
+- **MIRROR**: `SCHEMA_MIGRATION` (v4, db.py:254-265).
+- **IMPORTS**: None new.
+- **GOTCHA**:
+  - Must bump `SCHEMA_VERSION` or the early-return at line 176-177 skips v8.
+  - `_schema_initialized` cache at line 146 uses DB file path; tests use fresh `tmp_path` so cache is not an issue.
+  - `ALTER TABLE ADD COLUMN ... NOT NULL DEFAULT 0` applies the default to existing rows — no backfill.
+- **VALIDATE**: See "Migration Validation" in Validation Commands.
+
+### Task 2: DB helpers — strike counter mutations
+
+- **ACTION**: Edit `src/amz_scout/db.py`, add two functions next to `update_asin_status` (around line 1856).
+- **IMPLEMENT**:
+  ```python
+  def increment_not_listed_strikes(
+      conn: sqlite3.Connection,
+      product_id: int,
+      marketplace: str,
+  ) -> int:
+      """Increment the empty-observation strike counter. Returns new value.
+
+      Does NOT flip ``status``. Callers that cross
+      :data:`NOT_LISTED_STRIKE_THRESHOLD` should follow up with
+      :func:`update_asin_status` to preserve ``last_checked`` bookkeeping.
+      """
+      with conn:
+          conn.execute(
+              "UPDATE product_asins SET "
+              "not_listed_strikes = not_listed_strikes + 1, "
+              "updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') "
+              "WHERE product_id = ? AND marketplace = ?",
+              (product_id, marketplace),
+          )
+          row = conn.execute(
+              "SELECT not_listed_strikes FROM product_asins "
+              "WHERE product_id = ? AND marketplace = ?",
+              (product_id, marketplace),
+          ).fetchone()
+      return int(row["not_listed_strikes"]) if row else 0
+
+
+  def clear_not_listed_strikes(
+      conn: sqlite3.Connection,
+      product_id: int,
+      marketplace: str,
+  ) -> None:
+      """Reset the empty-observation strike counter to 0.
+
+      Called on any fetch that returns a non-empty title or csv.
+      """
+      with conn:
+          conn.execute(
+              "UPDATE product_asins SET "
+              "not_listed_strikes = 0, "
+              "updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') "
+              "WHERE product_id = ? AND marketplace = ? "
+              "AND not_listed_strikes != 0",
+              (product_id, marketplace),
+          )
+  ```
+- **MIRROR**: `update_asin_status` shape (db.py:1856-1871). SELECT-after-UPDATE inside same `with conn:` block (no `RETURNING`, to match existing db.py style).
+- **IMPORTS**: None new.
+- **GOTCHA**:
+  - `AND not_listed_strikes != 0` guard in `clear_*` avoids `updated_at` churn on the hot path.
+- **VALIDATE**: Task 5 unit tests.
+
+### Task 3: API — split `_try_mark_not_listed` into observation helpers
+
+- **ACTION**: Edit `src/amz_scout/api.py`. Replace `_try_mark_not_listed` (lines 398-420).
+- **IMPLEMENT**:
+  ```python
+  def _record_empty_observation(
+      conn: sqlite3.Connection,
+      asin: str,
+      site: str,
+  ) -> tuple[int, bool]:
+      """Record a Keepa 'no data' observation for a registered ASIN.
+
+      Returns ``(new_strike_count, flipped_to_not_listed)``. Unregistered
+      ASINs are a no-op — we only gate registered ones.
+      """
+      try:
+          from amz_scout.db import (
+              NOT_LISTED_STRIKE_THRESHOLD,
+              increment_not_listed_strikes,
+              update_asin_status,
+          )
+          row = conn.execute(
+              "SELECT product_id, status FROM product_asins "
+              "WHERE asin = ? AND marketplace = ?",
+              (asin, site),
+          ).fetchone()
+          if not row:
+              return (0, False)
+          strikes = increment_not_listed_strikes(conn, row["product_id"], site)
+          if row["status"] == "active" and strikes >= NOT_LISTED_STRIKE_THRESHOLD:
+              update_asin_status(
+                  conn,
+                  row["product_id"],
+                  site,
+                  "not_listed",
+                  notes=(
+                      f"Keepa returned empty data {strikes}x in a row "
+                      "(transient-failure guard threshold reached)"
+                  ),
+              )
+              return (strikes, True)
+          return (strikes, False)
+      except Exception:
+          logger.exception(
+              "Failed to record empty observation for ASIN %s/%s", asin, site,
+          )
+          return (0, False)
+
+
+  def _record_successful_observation(
+      conn: sqlite3.Connection,
+      asin: str,
+      site: str,
+  ) -> None:
+      """Reset the strike counter after a Keepa fetch returned data."""
+      try:
+          from amz_scout.db import clear_not_listed_strikes
+          row = conn.execute(
+              "SELECT product_id FROM product_asins "
+              "WHERE asin = ? AND marketplace = ?",
+              (asin, site),
+          ).fetchone()
+          if row:
+              clear_not_listed_strikes(conn, row["product_id"], site)
+      except Exception:
+          logger.exception(
+              "Failed to clear empty-observation strikes for %s/%s", asin, site,
+          )
+  ```
+  Delete the old `_try_mark_not_listed` after Task 4 removes its only caller.
+- **MIRROR**: `_try_mark_not_listed` shape (api.py:398-420) — lazy imports, `try/except`, `logger.exception`, no-op when unregistered.
+- **IMPORTS**: None at module scope (lazy-import style).
+- **GOTCHA**:
+  - Threshold gate is `status == 'active' AND strikes >= THRESHOLD` — already-`not_listed` rows silently increment their counter without note churn.
+  - `_record_successful_observation` is cheap even when strikes already 0 (guarded by `clear_not_listed_strikes`).
+- **VALIDATE**: Task 5 unit tests.
+
+### Task 4: API — rewrite `ensure_keepa_data` post-fetch validation
+
+- **ACTION**: Edit `src/amz_scout/api.py` lines 904-930.
+- **IMPLEMENT** (replacing the current loop body):
+  ```python
+  from amz_scout.db import NOT_LISTED_STRIKE_THRESHOLD as _STRIKE_THRESHOLD
+
+  for o in fetched_outcomes:
+      ph = o.price_history
+      fetch_error = ph.fetch_error if ph else ""
+      title = title_map.get((o.asin, o.site), "")
+      has_csv = ph and (
+          ph.buybox_current is not None or ph.new_current is not None
+      )
+
+      if fetch_error:
+          # Transient Keepa failure — do NOT touch status or strikes.
+          warnings.append(
+              f"{o.model} / {o.site} ({o.asin}): "
+              f"Transient Keepa failure ({fetch_error}); "
+              "status unchanged, cached data (if any) still valid."
+          )
+          continue
+
+      if not title and not has_csv:
+          strikes, flipped = _record_empty_observation(conn, o.asin, o.site)
+          brand = o.freshness.brand
+          if flipped:
+              warnings.append(
+                  f"{o.model} / {o.site} ({o.asin}): "
+                  f"Marked not_listed after {strikes} consecutive empty "
+                  "responses. Run discover_asin("
+                  f"'{brand}', '{o.model}', '{o.site}') for a valid ASIN, "
+                  "or update_asin_status(status='active') if re-listed."
+              )
+          elif strikes > 0:
+              warnings.append(
+                  f"{o.model} / {o.site} ({o.asin}): "
+                  f"Empty Keepa response (strike {strikes}/"
+                  f"{_STRIKE_THRESHOLD}); status unchanged. "
+                  "Will mark not_listed after consecutive threshold."
+              )
+          else:
+              # Unregistered ASIN — preserve legacy actionable warning.
+              warnings.append(
+                  f"{o.model} / {o.site} ({o.asin}): "
+                  "ASIN has no data — likely wrong or not listed. "
+                  f"Call discover_asin('{brand}', '{o.model}', "
+                  f"'{o.site}') to search for the correct ASIN."
+              )
+          continue
+
+      # Fetch returned data — reset any in-flight strike streak.
+      _record_successful_observation(conn, o.asin, o.site)
+  ```
+  Use a lazy local import for `_STRIKE_THRESHOLD`, mirroring the existing lazy-import style.
+- **MIRROR**: `WARNING_ACCUMULATION` (api.py:904-948). Envelope shape unchanged.
+- **IMPORTS**: `from amz_scout.db import NOT_LISTED_STRIKE_THRESHOLD as _STRIKE_THRESHOLD` (lazy, inside the function).
+- **GOTCHA**:
+  - Preserve the unregistered-ASIN warning text so operators pasting a bad ASIN still get actionable feedback.
+  - `_record_successful_observation` only runs in the "fetch returned data" arm.
+  - The `has_csv` truthiness expression currently short-circuits on `None` price_history — keep the exact shape.
+  - Grep-verify: the only caller of `_try_mark_not_listed` is this block. Delete the function after replacing.
+- **VALIDATE**: Task 5 integration test.
+
+### Task 5: Tests
+
+- **ACTION**: Edit `tests/test_api.py`. Add three classes.
+- **IMPLEMENT**:
+
+  ```python
+  class TestEmptyObservationStrikes:
+      """Strike counter behaviour for _record_empty_observation."""
+
+      def _seed(self, tmp_path, asin="B0STRIKE01", status="active"):
+          from amz_scout.db import init_schema, register_asin, register_product
+          db_path = tmp_path / "strikes.db"
+          c = sqlite3.connect(str(db_path))
+          c.row_factory = sqlite3.Row
+          init_schema(c)
+          pid, _ = register_product(c, "Router", "BrandX", "ModelX")
+          register_asin(c, pid, "UK", asin, status=status, notes="")
+          return c, pid
+
+      def test_unregistered_asin_is_noop(self, tmp_path):
+          from amz_scout.api import _record_empty_observation
+          c, _ = self._seed(tmp_path)
+          strikes, flipped = _record_empty_observation(c, "B0UNREG0001", "UK")
+          assert (strikes, flipped) == (0, False)
+          c.close()
+
+      def test_first_empty_increments_only(self, tmp_path):
+          from amz_scout.api import _record_empty_observation
+          c, pid = self._seed(tmp_path)
+          strikes, flipped = _record_empty_observation(c, "B0STRIKE01", "UK")
+          assert strikes == 1
+          assert flipped is False
+          row = c.execute(
+              "SELECT status, not_listed_strikes FROM product_asins "
+              "WHERE product_id = ? AND marketplace = 'UK'", (pid,),
+          ).fetchone()
+          assert row["status"] == "active"
+          assert row["not_listed_strikes"] == 1
+          c.close()
+
+      def test_threshold_flips_to_not_listed(self, tmp_path):
+          from amz_scout.api import _record_empty_observation
+          from amz_scout.db import NOT_LISTED_STRIKE_THRESHOLD
+          c, pid = self._seed(tmp_path)
+          for _ in range(NOT_LISTED_STRIKE_THRESHOLD - 1):
+              _record_empty_observation(c, "B0STRIKE01", "UK")
+          strikes, flipped = _record_empty_observation(c, "B0STRIKE01", "UK")
+          assert strikes == NOT_LISTED_STRIKE_THRESHOLD
+          assert flipped is True
+          row = c.execute(
+              "SELECT status FROM product_asins "
+              "WHERE product_id = ? AND marketplace = 'UK'", (pid,),
+          ).fetchone()
+          assert row["status"] == "not_listed"
+          c.close()
+
+      def test_successful_observation_resets_strikes(self, tmp_path):
+          from amz_scout.api import (
+              _record_empty_observation, _record_successful_observation,
+          )
+          c, pid = self._seed(tmp_path)
+          _record_empty_observation(c, "B0STRIKE01", "UK")
+          _record_empty_observation(c, "B0STRIKE01", "UK")
+          _record_successful_observation(c, "B0STRIKE01", "UK")
+          row = c.execute(
+              "SELECT not_listed_strikes FROM product_asins "
+              "WHERE product_id = ? AND marketplace = 'UK'", (pid,),
+          ).fetchone()
+          assert row["not_listed_strikes"] == 0
+          c.close()
+
+      def test_already_not_listed_does_not_rewrite_notes(self, tmp_path):
+          from amz_scout.api import _record_empty_observation
+          c, _ = self._seed(tmp_path, status="not_listed")
+          strikes, flipped = _record_empty_observation(c, "B0STRIKE01", "UK")
+          assert flipped is False
+          c.close()
+
+
+  class TestEnsureKeepaDataTransientVsPermanent:
+      def test_transient_blip_preserves_status(self, config_dir, monkeypatch):
+          """fetch_error != '' must not touch status or strikes."""
+          import amz_scout.api as api_mod
+          from amz_scout.db import register_asin, register_product
+          from amz_scout.keepa_service import KeepaProductOutcome, KeepaResult
+          from amz_scout.freshness import ProductFreshness
+          from amz_scout.models import PriceHistory
+
+          tmp_path, proj_path = config_dir
+          db_path = tmp_path / "output" / "amz_scout.db"
+          c = sqlite3.connect(str(db_path))
+          c.row_factory = sqlite3.Row
+          pid, _ = register_product(c, "Router", "BrandY", "ModelY")
+          register_asin(c, pid, "UK", "B0TRANS0001", status="active", notes="")
+          c.close()
+
+          def fake_get_keepa_data(conn, products, sites, marketplaces, **_):
+              pf = ProductFreshness(
+                  asin="B0TRANS0001", site="UK", brand="BrandY",
+                  model="ModelY", action="needs_fetch", age_days=None,
+                  fetched_at=None, mode=None,
+              )
+              ph = PriceHistory(
+                  date="2026-04-21", site="UK", category="Router",
+                  brand="BrandY", model="ModelY", asin="B0TRANS0001",
+                  fetch_error="rate_limited",
+              )
+              outcome = KeepaProductOutcome(
+                  asin="B0TRANS0001", site="UK", model="ModelY",
+                  source="fetched", price_history=ph, freshness=pf,
+              )
+              return KeepaResult(outcomes=[outcome], tokens_used=0,
+                                 tokens_remaining=60)
+
+          monkeypatch.setattr(api_mod, "get_keepa_data", fake_get_keepa_data)
+          r = ensure_keepa_data(proj_path, marketplace="UK")
+          assert r["ok"] is True
+          c = sqlite3.connect(str(db_path)); c.row_factory = sqlite3.Row
+          row = c.execute(
+              "SELECT status, not_listed_strikes FROM product_asins "
+              "WHERE asin = 'B0TRANS0001' AND marketplace = 'UK'"
+          ).fetchone()
+          assert row["status"] == "active"
+          assert row["not_listed_strikes"] == 0
+          assert any("Transient Keepa failure" in w
+                     for w in r["meta"]["warnings"])
+          c.close()
+
+
+  class TestAsinStatusRecovery:
+      """Manual not_listed -> active recovery via update_asin_status."""
+
+      def test_update_asin_status_restores_active(self, tmp_path):
+          from amz_scout.db import (
+              init_schema, register_asin, register_product, update_asin_status,
+          )
+          from amz_scout.api import _resolve_asin
+          db_path = tmp_path / "recovery.db"
+          c = sqlite3.connect(str(db_path)); c.row_factory = sqlite3.Row
+          init_schema(c)
+          pid, _ = register_product(c, "Router", "B", "M")
+          register_asin(c, pid, "UK", "B0RECOV0001",
+                        status="not_listed", notes="")
+          with pytest.raises(ValueError, match="not_listed"):
+              _resolve_asin([], "B0RECOV0001", marketplace="UK", conn=c)
+          update_asin_status(c, pid, "UK", "active",
+                             notes="operator confirmed re-listed")
+          asin, *_ = _resolve_asin([], "B0RECOV0001",
+                                   marketplace="UK", conn=c)
+          assert asin == "B0RECOV0001"
+          c.close()
+  ```
+- **MIRROR**: `TestResolveAsinStatusGate` (test_api.py:1030-1102) + monkey-patch pattern.
+- **IMPORTS**: Use existing test imports; add `NOT_LISTED_STRIKE_THRESHOLD` via lazy `from amz_scout.db import`.
+- **GOTCHA**:
+  - Verify `ProductFreshness` / `PriceHistory` field names via `grep -n "@dataclass" src/amz_scout/freshness.py src/amz_scout/models.py` before finalizing fixtures — dataclass kwargs must match exactly.
+  - Monkey-patch `api_mod.get_keepa_data` (the symbol imported into api.py), not `keepa_service.get_keepa_data`.
+- **VALIDATE**: `pytest tests/test_api.py -k "Strike or Recovery or Transient" -v` green.
+
+### Task 6: Docs — DEVELOPER.md
+
+- **ACTION**: Edit `docs/DEVELOPER.md`.
+- **IMPLEMENT**:
+  1. Append after line 112 (v7 row):
+     ```
+     | 8 | Transient-failure guard | Add `not_listed_strikes` counter to `product_asins`; require N consecutive genuine empty observations before flipping to `not_listed` |
+     ```
+  2. Replace the state diagram (lines 163-168):
+     ```mermaid
+     stateDiagram-v2
+         [*] --> active: register / discover / auto-register
+         active --> active: transient fetch_error → log only
+         active --> active: genuine empty, strikes < N → increment counter
+         active --> not_listed: N consecutive genuine empty responses
+         active --> active: any fetch with data → strikes reset to 0
+         not_listed --> active: manual recovery via update_asin_status
+     ```
+  3. Under "Query Gate" (around line 155), add a short paragraph describing `NOT_LISTED_STRIKE_THRESHOLD = 3`, the `fetch_error` signal from `PriceHistory`, and the distinction between transient and genuine empty.
+- **MIRROR**: Existing migrations table + mermaid diagram style.
+- **IMPORTS**: N/A.
+- **GOTCHA**: Append only — do not renumber historical rows.
+- **VALIDATE**: `grep -n "^| 8 |" docs/DEVELOPER.md` returns the new row.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+| Test | Input | Expected | Edge Case? |
+|---|---|---|---|
+| `test_unregistered_asin_is_noop` | `_record_empty_observation` on empty registry | `(0, False)` | ✓ |
+| `test_first_empty_increments_only` | Registered ASIN, one empty | strikes=1, active | ✓ |
+| `test_threshold_flips_to_not_listed` | Registered ASIN, N empty | strikes=N, not_listed, flipped=True | ✓ |
+| `test_successful_observation_resets_strikes` | 2 empties + 1 success | strikes=0, active | ✓ |
+| `test_already_not_listed_does_not_rewrite_notes` | already `not_listed`, one empty | flipped=False | ✓ |
+| `test_transient_blip_preserves_status` | `fetch_error="rate_limited"` | status=active, strikes=0, "Transient" warning | ✓ (the bug itself) |
+| `test_update_asin_status_restores_active` | not_listed → `update_asin_status("active")` | `_resolve_asin` no longer raises | ✓ (#11 recovery gap) |
+
+### Edge Cases Checklist
+- [x] Unregistered ASIN — early return, no crash.
+- [x] Already `not_listed` ASIN — strikes increment, no status churn.
+- [x] Concurrent fetch race — SQLite file lock serializes updates; accepted.
+- [x] `price_history is None` on a fetched outcome — defensive guard.
+- [x] `fetch_error == "max_retries_exhausted"` — classified as transient (documented).
+- [x] Fresh DB — baseline schema has the column, no migration runs.
+- [x] v7 DB — `ALTER TABLE ADD COLUMN` appends with default 0.
+- [x] Already-v8 DB — idempotent (PRAGMA guard + INSERT OR IGNORE).
+
+---
+
+## Validation Commands
+
+### Static Analysis
+```bash
+ruff check src/ tests/
+```
+EXPECT: zero lint errors (`line-length = 100`).
+
+```bash
+python -c "import amz_scout.api, amz_scout.db; print('import ok')"
+```
+EXPECT: `import ok` — catches circular-import regressions.
+
+### Unit Tests
+```bash
+pytest tests/test_api.py -v
+pytest tests/test_db.py -v
+```
+EXPECT: all green including 7 new tests.
+
+### Full Suite
+```bash
+pytest --cov=src/amz_scout --cov-report=term-missing
+```
+EXPECT: no regressions; coverage on new helpers ≥ 90%.
+
+### DB Schema Validation
+```bash
+python - <<'PY'
+import sqlite3, tempfile, pathlib
+from amz_scout.db import init_schema, SCHEMA_VERSION
+p = pathlib.Path(tempfile.mkdtemp()) / "check.db"
+c = sqlite3.connect(str(p)); c.row_factory = sqlite3.Row
+init_schema(c)
+cols = {r["name"] for r in c.execute("PRAGMA table_info(product_asins)")}
+assert "not_listed_strikes" in cols, cols
+ver = c.execute("SELECT MAX(version) FROM schema_migrations").fetchone()[0]
+assert ver == SCHEMA_VERSION == 8, (ver, SCHEMA_VERSION)
+print("schema v8 ok")
+PY
+```
+EXPECT: `schema v8 ok`.
+
+### Migration Validation (v7 → v8)
+```bash
+python - <<'PY'
+import sqlite3, pathlib, tempfile
+p = pathlib.Path(tempfile.mkdtemp()) / "legacy.db"
+c = sqlite3.connect(str(p))
+c.executescript("""
+CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, description TEXT,
+  applied_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')));
+INSERT INTO schema_migrations (version, description) VALUES (7, 'legacy');
+CREATE TABLE products (id INTEGER PRIMARY KEY, category TEXT, brand TEXT,
+  model TEXT, brand_key TEXT, model_key TEXT, search_keywords TEXT DEFAULT '',
+  created_at TEXT, updated_at TEXT, UNIQUE(brand_key, model_key));
+CREATE TABLE product_asins (product_id INTEGER, marketplace TEXT, asin TEXT,
+  status TEXT DEFAULT 'active' CHECK(status IN ('active','not_listed')),
+  notes TEXT DEFAULT '', last_checked TEXT,
+  created_at TEXT, updated_at TEXT,
+  PRIMARY KEY(product_id, marketplace));
+""")
+c.commit(); c.close()
+
+from amz_scout.db import init_schema
+c = sqlite3.connect(str(p)); c.row_factory = sqlite3.Row
+init_schema(c)
+cols = {r["name"] for r in c.execute("PRAGMA table_info(product_asins)")}
+assert "not_listed_strikes" in cols
+print("v7->v8 migration ok")
+PY
+```
+EXPECT: `v7->v8 migration ok`.
+
+### Manual Validation
+- [ ] DB with one `(active, strikes=0)` row.
+- [ ] Call `_record_empty_observation` three times — strikes 1, 2, 3 and status flip on third.
+- [ ] `update_asin_status(..., "active")` — `_resolve_asin` no longer raises.
+- [ ] Webapp warnings string reads naturally for operators.
+
+---
+
+## Acceptance Criteria
+- [ ] Schema version 8; column `not_listed_strikes` exists.
+- [ ] Transient fetch errors never touch `status` or `not_listed_strikes`.
+- [ ] Genuine empty responses increment the counter; flip only at threshold.
+- [ ] Successful fetches reset counter to 0.
+- [ ] `not_listed → active` recovery has an explicit test.
+- [ ] All validation commands pass.
+- [ ] No regressions in `TestResolveAsinStatusGate`.
+- [ ] DEVELOPER.md migrations table + diagram updated.
+
+## Completion Checklist
+- [ ] Lazy imports, `with conn:`, `logger.exception` patterns followed.
+- [ ] `try/except Exception` around optional mutations.
+- [ ] Module-level `logger = logging.getLogger(__name__)` already present.
+- [ ] Tests use `TestResolveAsinStatusGate` seeding style.
+- [ ] Threshold centralised as `NOT_LISTED_STRIKE_THRESHOLD` constant.
+- [ ] Docs updated.
+- [ ] No scope creep (no new status values, no background jobs, no CLI flags).
+- [ ] Self-contained — no open questions.
+
+## Risks
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `_schema_initialized` cache skips v8 on stale worker | Low | Medium | Cache key is file path; migration idempotent. |
+| Threshold N=3 miscalibrated | Medium | Low | One-line constant change; documented. |
+| Concurrent callers race on `(product_id, marketplace)` | Low | Low | SQLite file lock serializes; double-increment is the intended semantic. |
+| Existing stale `not_listed` rows don't auto-recover | Certain | Medium | Out of scope; manual recovery documented; follow-up issue suggested. |
+
+## Notes
+- `availability_amazon == -1` is absent when `products=[]`, so it can't accelerate
+  the transient-blip case. Follow-up: use it to lower N for ASINs Keepa explicitly
+  reports as unavailable.
+- PR body should read `Closes #11` — safe usage of the auto-close keyword
+  because this PR actually closes the issue. (Per memory
+  `feedback_github_close_keywords`.)

--- a/.claude/PRPs/reports/fix-transient-failure-permanent-dead-listing-report.md
+++ b/.claude/PRPs/reports/fix-transient-failure-permanent-dead-listing-report.md
@@ -1,0 +1,104 @@
+# Implementation Report: Fix transient-failure permanent dead-listing (closes #11)
+
+## Summary
+
+Replaced the one-shot "empty title + no csv → permanent `not_listed`"
+post-fetch check in `ensure_keepa_data` with a two-gate decision:
+
+1. Responses with a populated `PriceHistory.fetch_error` (rate_limited,
+   network, api_error, etc.) are classified as **transient** — status
+   and strikes are left untouched; a clear warning surfaces in the
+   envelope `meta["warnings"]`.
+2. Eligible empty responses (`fetch_error == ""`) increment a new
+   `product_asins.not_listed_strikes` INTEGER column. The row is only
+   flipped to `not_listed` after
+   `NOT_LISTED_STRIKE_THRESHOLD == 3` consecutive observations; any
+   fetch that returns data resets the counter to 0.
+
+Manual recovery (`update_asin_status(..., status='active')`) now has
+explicit test coverage, closing the other gap noted in issue #11.
+
+## Assessment vs Reality
+
+| Metric | Predicted (Plan) | Actual |
+|---|---|---|
+| Complexity | Medium | Medium |
+| Files Changed | 4 | 5 |
+| LOC delta | ~180 new | +485 / -35 (≈ 450 new) |
+| Tests added | 7 | 8 (added `test_genuine_empty_increments_strike_under_threshold` beyond plan) |
+
+`tests/test_db.py` was the 5th file — necessary scaffolding updates
+for the schema-version bump that the plan didn't anticipate.
+
+## Tasks Completed
+
+| # | Task | Status | Notes |
+|---|---|---|---|
+| 1 | Schema — bump v8 + add `not_listed_strikes` | Complete | Required an extra `_SCHEMA_SQL` seed insert for v8 (plan missed this) |
+| 2 | DB helpers — increment/clear strikes | Complete | `clear` guards `WHERE not_listed_strikes != 0` to avoid `updated_at` churn |
+| 3 | API — split `_try_mark_not_listed` | Complete | `_record_empty_observation` returns `(strikes, flipped)`; `_record_successful_observation` resets |
+| 4 | API — rewrite `ensure_keepa_data` post-fetch | Complete | Three-branch flow: transient / empty / success |
+| 5 | Tests — 3 new test classes | Complete | 8 new tests total (5 unit + 2 integration + 1 recovery) |
+| 6 | Docs — DEVELOPER.md | Complete | v8 row + "Transient-Failure Guard" section + updated mermaid diagram |
+
+## Validation Results
+
+| Level | Status | Notes |
+|---|---|---|
+| Static Analysis | Pass | `ruff check src/ tests/` — all checks passed |
+| Circular-import guard | Pass | `import amz_scout.api, amz_scout.db` clean |
+| Unit + integration tests | Pass | 312 passed, 8 skipped (pre-existing) |
+| Schema validation | Pass | `SCHEMA_VERSION == 8`, column present |
+| v7→v8 migration | Pass | Synthetic v7 DB migrates in place; legacy rows backfill to 0 |
+
+## Files Changed
+
+| File | Action | Lines |
+|---|---|---|
+| `src/amz_scout/db.py` | UPDATE | +84 / -3 |
+| `src/amz_scout/api.py` | UPDATE | +133 / -27 |
+| `tests/test_api.py` | UPDATE | +233 / 0 |
+| `tests/test_db.py` | UPDATE | +28 / -11 (scaffolding) |
+| `docs/DEVELOPER.md` | UPDATE | +31 / -1 |
+
+## Deviations from Plan
+
+| Deviation | Why | Evidence |
+|---|---|---|
+| **Monkey-patch target** changed from `api_mod.get_keepa_data` to `amz_scout.keepa_service.get_keepa_data` | `get_keepa_data` is a **lazy import inside `ensure_keepa_data`** (api.py:821), not a module-level binding. Patching the caller module has no effect because `api_mod.get_keepa_data` doesn't exist as an attribute. | `src/amz_scout/api.py:821` `from amz_scout.keepa_service import get_keepa_data` inside the function body |
+| **`ProductFreshness` fixture fields** corrected | Plan said `action="needs_fetch"` + `mode=None`; real dataclass Literal is `"use_cache" / "fetch" / "skip"` and there is a required `reason: str` field instead of `mode`. | `src/amz_scout/freshness.py:27-38` |
+| **Test ASIN `B0RECOV0001` shortened** to `B0RECOV001` | Plan used an 11-char string; `_resolve_asin` ASIN regex is `^[A-Z0-9]{10}$`, so 11-char strings fall through to "Product not found" instead of hitting the `not_listed` gate. Transient/empty ASINs (`B0TRANS0001`, `B0EMPTY0001`) also >=11 chars but are OK because they never go through `_resolve_asin` in those tests. | `src/amz_scout/api.py` `_ASIN_RE` |
+| **`_SCHEMA_SQL` seed insert for v8** added | Plan only mentioned `_migrate()` block + baseline `CREATE TABLE`; missed that `_SCHEMA_SQL` also seeds every `schema_migrations` row. Without it, fresh DB would show `MAX(version)=7` even with column present — then re-run v8 migration on next open (idempotent but semantically confusing). | `src/amz_scout/db.py:597-598` |
+| **`test_db.py` scaffolding edits** (5th file) | v6/v7 migration tests force-downgrade schema via `DELETE FROM schema_migrations WHERE version IN (...)`. With v8 added, these deletes left `MAX(version)=8`, causing `_migrate` to early-return and the target migration never to run. Changed to `WHERE version >= N`. Also explicit column list in v6 `INSERT SELECT` to avoid column-count mismatch with the new `not_listed_strikes` column. | `tests/test_db.py:435, 457-467, 624, 768` |
+| **Extra integration test** `test_genuine_empty_increments_strike_under_threshold` | Complemented the transient test to exercise the symmetric "genuine empty → strike increments" branch end-to-end through `ensure_keepa_data`. | `tests/test_api.py` |
+
+## Issues Encountered
+
+1. **Lazy-import monkey-patch trap** — first attempt followed plan
+   literally; test silently no-op'd because `api_mod.get_keepa_data`
+   doesn't exist. Resolved by patching the source module instead.
+2. **ASIN regex mismatch** — `B0RECOV0001` (11 chars) never reached the
+   `not_listed` gate. Discovered via test failure; fixed by truncating.
+3. **Transitive test breakage** — schema bump broke v6/v7 migration
+   tests because they depend on `MAX(version)` relative to
+   `SCHEMA_VERSION`. Resolved by changing literal version lists to
+   range deletes (`WHERE version >= N`). Added a comment so future
+   schema bumps don't repeat the same regression.
+
+## Tests Written
+
+| Test File | Class | Tests | Coverage |
+|---|---|---|---|
+| `tests/test_api.py` | `TestEmptyObservationStrikes` | 5 | unregistered no-op, first increment, threshold flip, success reset, already-not_listed path |
+| `tests/test_api.py` | `TestEnsureKeepaDataTransientVsPermanent` | 2 | transient blip preserves status; genuine empty increments strike |
+| `tests/test_api.py` | `TestAsinStatusRecovery` | 1 | `not_listed -> active` recovery restores `_resolve_asin` pass-through |
+
+## Next Steps
+
+- [ ] Code review via `/code-review`
+- [ ] Create PR via `/prp-pr` (body: `Closes #11`)
+- [ ] (Follow-up, not this PR) Use `keepa_products.availability_amazon == -1`
+      to lower the strike threshold for ASINs Keepa explicitly reports
+      as unavailable
+- [ ] (Follow-up, not this PR) Background `not_listed -> active`
+      auto-recovery job

--- a/.claude/PRPs/reviews/local-review-fix-transient-failure-permanent-dead-listing.md
+++ b/.claude/PRPs/reviews/local-review-fix-transient-failure-permanent-dead-listing.md
@@ -1,0 +1,149 @@
+# Local Review: fix/transient-failure-permanent-dead-listing (issue #11)
+
+**Reviewed**: 2026-04-21
+**Branch**: fix/transient-failure-permanent-dead-listing
+**Scope**: 5 files, +485/-35
+**Decision**: **APPROVE** (with MEDIUM/LOW advisory notes)
+
+## Summary
+
+Replaces the "1 empty fetch → permanent `not_listed`" blacklisting rule
+with a strike-counter guard: transient Keepa failures (non-empty
+`PriceHistory.fetch_error`) leave status untouched; genuine empty
+responses (`fetch_error == ""`) increment `product_asins.not_listed_strikes`,
+and only after `NOT_LISTED_STRIKE_THRESHOLD` (=3) consecutive eligible
+observations does the row flip to `not_listed`. Any fetch with data
+resets the counter. Manual `not_listed → active` recovery path now has
+explicit test coverage.
+
+Implementation matches the plan faithfully; deviations (monkey-patch
+target, ASIN regex width, `_SCHEMA_SQL` seed insert, test_db
+scaffolding edits) are all legitimate and surfaced in the report.
+
+## Findings
+
+### CRITICAL
+None.
+
+### HIGH
+None.
+
+### MEDIUM
+
+1. **Misleading warning text for already-`not_listed` rows**
+   - File: `src/amz_scout/api.py:1004-1011`
+   - Severity: MEDIUM (UX / observability)
+   - When `ensure_keepa_data` re-fetches an already-`not_listed`
+     ASIN and the response is still genuine empty,
+     `_record_empty_observation` increments strikes and returns
+     `(strikes, flipped=False)`. Because `flipped` is False and
+     `strikes > 0`, the code emits:
+     > "Empty Keepa response (strike 4/3); status unchanged. Will mark
+     > not_listed after consecutive threshold."
+   - Reads as semantically wrong: the ratio "4/3" is nonsensical,
+     and the "will mark not_listed" promise is vacuous because the
+     row is already `not_listed`.
+   - Suggested fix: carry back the `status` from
+     `_record_empty_observation` (change return to
+     `(strikes, flipped, was_active_on_entry)` or have caller
+     re-read) so the warning branch can distinguish:
+     - `status == 'active'` + `strikes < THRESHOLD` → current
+       "strike N/3" progression text
+     - `status == 'not_listed'` → "Still observed as not_listed
+       (observations: N)" or skip entirely
+   - Alternatively, accept as-is and add an explicit inline comment
+     that the ratio is intentionally unbounded for observational
+     rows. The plan's Edge Cases checklist covers the *behavior* but
+     not the *warning copy*, so either choice is defensible.
+
+### LOW
+
+1. **`price_history=None` on `source="fetched"` is treated as genuine empty**
+   - File: `src/amz_scout/api.py:969-975`
+   - `keepa_service.py:173` uses `history_map.get(pf.asin)`, which
+     returns `None` if the scraper didn't yield a record for that
+     ASIN. The new code short-circuits
+     `fetch_error = ph.fetch_error if ph else ""`, so a `None`
+     price_history is classified as **genuine empty** and increments
+     strikes.
+   - In practice the scraper always populates via `_empty_history()`,
+     so the `None` path is theoretical — but the plan's Edge Cases
+     checklist flags this as a "defensive guard" without a clear
+     policy. Preserving prior behavior here is OK; a later follow-up
+     could reclassify `price_history is None` as transient (since
+     it means the scraper never got a response for that ASIN).
+
+2. **Unbounded `not_listed_strikes` growth on already-delisted rows**
+   - File: `src/amz_scout/api.py:414-446`
+   - Counter has no upper cap; rows re-fetched for months will grow
+     to 3-digit values. Documented in the docstring as an
+     "observational log". No correctness impact (SQLite INTEGER holds
+     2^63), but can be mildly confusing during manual DB inspection.
+   - If the follow-up to use `keepa_products.availability_amazon == -1`
+     to lower N lands later, consider capping strikes at some value
+     or resetting when flipping to not_listed.
+
+### Not a finding, worth noting
+
+- **Migration ordering** — v8 is inside the main `with conn:` txn,
+  while v7 runs afterward outside the txn (PRAGMA foreign_keys
+  requirement). This inverts version order temporally (v8 before v7
+  by wall-clock), but `_migrate_to_v7` only rebuilds the `products`
+  table and does NOT touch `product_asins`, so the `not_listed_strikes`
+  column added in v8 is preserved. Verified with the synthetic v7→v8
+  legacy migration script — passes.
+
+- **SQL construction in `ensure_keepa_data`** — `conds` f-string only
+  concatenates fixed `(asin = ? AND site = ?)` fragments and fully
+  parameterizes user values. No injection risk. Pre-existing pattern.
+
+- **Concurrency** — `_record_empty_observation` does a SELECT, then
+  calls `increment_not_listed_strikes` (its own `with conn:`), then
+  conditionally `update_asin_status` (its own `with conn:`). SQLite's
+  file lock serializes writes; the worst-case race is a stale-status
+  read between SELECT and UPDATE which results in a possible missed
+  flip that self-corrects on the next call. Acceptable.
+
+## Validation Results
+
+| Check | Result | Notes |
+|---|---|---|
+| `ruff check src/ tests/` | PASS | all checks passed |
+| `import amz_scout.api, amz_scout.db` | PASS | no circular-import regression |
+| Fresh DB schema v8 validation | PASS | `not_listed_strikes` present, MAX(version)=8 |
+| v7 → v8 migration on synthetic legacy DB | PASS | column added by ALTER TABLE |
+| `pytest tests/test_api.py tests/test_db.py` | PASS | 154/154 |
+| `pytest` full suite | PASS | 312 passed, 8 skipped, 0 failures |
+| `pytest -k "Strike or Recovery or Transient or Genuine"` | PASS | 8/8 new tests |
+
+## Files Reviewed
+
+| File | Change | Notes |
+|---|---|---|
+| `src/amz_scout/db.py` | Modified | v8 migration, baseline column + seed, two strike helpers |
+| `src/amz_scout/api.py` | Modified | Split `_try_mark_not_listed` → two observation helpers; three-branch post-fetch loop |
+| `tests/test_api.py` | Modified | +233 lines, 8 new tests across 3 classes |
+| `tests/test_db.py` | Modified | Version bump + scaffolding adapted (`WHERE version >= N`, explicit column list) |
+| `docs/DEVELOPER.md` | Modified | v8 migrations row, Transient-Failure Guard section, updated state diagram |
+
+Untracked (non-source):
+- `.claude/PRPs/plans/completed/fix-transient-failure-permanent-dead-listing.plan.md`
+- `.claude/PRPs/reports/fix-transient-failure-permanent-dead-listing-report.md`
+
+## Decision Rationale
+
+Zero CRITICAL / HIGH issues. All validation passes. The MEDIUM finding
+is pure UX polish on warning text for a narrow edge case; can ship as
+an incremental improvement or be deferred. LOW findings are pre-existing
+behavior preserved by this PR and call for follow-up items, not
+blockers.
+
+## Suggested Next Steps
+
+- (Optional) Tighten the warning copy for already-`not_listed` rows
+  per the MEDIUM finding (one-call-site change in `api.py`).
+- Proceed with `/prp-pr` — the plan's note about using `Closes #11` in
+  the body is correct (per `feedback_github_close_keywords` memory the
+  keyword is safe here because this PR does close the issue).
+- File follow-up issues for the two LOW items if the team wants to
+  track them.

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -111,13 +111,18 @@ cli.py  ────────────────────────
 | 6 | Remove intent validation | Collapse status to `active` / `not_listed` |
 | 7 | Normalize brand/model matching | Add `brand_key`/`model_key` + `UNIQUE(brand_key, model_key)` on `products`; merges literal-variant duplicates on upgrade |
 | 8 | Canonicalize `ean_list`/`upc_list` to GTIN-13 | Rewrite `keepa_products.ean_list` / `upc_list` JSON in place so UPC-12 and EAN-13 of the same physical product collide; no DDL |
+| 9 | Transient-failure guard | Add `not_listed_strikes` counter to `product_asins`; require N consecutive genuine empty observations before flipping to `not_listed` (issue #11) |
 
-**Partial-failure note (v7 ↔ v8 ordering)**: v7 runs outside the
+**Partial-failure note (v7 ↔ v8/v9 ordering)**: v7 runs outside the
 inner migration txn because it toggles `PRAGMA foreign_keys`; v8 runs
 inside. `_migrate` gates v7 by checking the actual `schema_migrations`
 record (not `MAX(version)`) so a pre-v7 DB whose v8 record commits
 before v7 fails will still retry v7 on reopen instead of treating
-`current = 8` as "all migrations applied".
+`current = 8` as "all migrations applied". v9 runs in its own
+`with conn:` after v7 so the `INSERT INTO schema_migrations (9, ...)`
+is committed independently of caller behavior — without the wrap,
+Python sqlite3 leaves an implicit transaction open and `conn.close()`
+without explicit commit would silently roll back the v9 record.
 
 ### Brand/Model Normalization (v7+)
 
@@ -177,7 +182,7 @@ queries should use the canonical GTIN-13 form.
 | Value | Meaning | Typical Trigger |
 |-------|---------|-----------------|
 | `active` | Default; queryable. Registered and not observed as delisted. | Default on insert; `add_product`, `discover_asin`, `_auto_register_from_keepa`, `register_asin` |
-| `not_listed` | Observed empty-title response from Keepa (ASIN dead/removed on Amazon) | `_try_mark_not_listed()` during `ensure_keepa_data` post-fetch validation |
+| `not_listed` | Observed empty-title response from Keepa (ASIN dead/removed on Amazon) | `_record_empty_observation()` during `ensure_keepa_data` post-fetch validation — flipped only after `NOT_LISTED_STRIKE_THRESHOLD` consecutive empty observations (transient-failure guard, v8+) |
 
 ### Design Principle — Intent vs Availability
 
@@ -195,13 +200,37 @@ queries should use the canonical GTIN-13 form.
 `active` rows pass through. This prevents the silent-failure bug where
 users would see "no data" when the real cause was a dead ASIN.
 
+### Transient-Failure Guard (v8+)
+
+A single Keepa blip (rate limit, network error, partial JSON) must not
+blacklist a live ASIN, so the `active → not_listed` transition is
+gated by a counter column `product_asins.not_listed_strikes`:
+
+- Only `PriceHistory.fetch_error == ""` responses are **eligible** —
+  anything with a populated `fetch_error` (`rate_limited`,
+  `invalid_response`, `api_error`, `network`, `unexpected`,
+  `max_retries_exhausted`) is treated as transient and leaves status
+  and strikes untouched.
+- Eligible responses with an empty title **and** no csv increment the
+  counter. The flip to `not_listed` fires only when strikes reach
+  `NOT_LISTED_STRIKE_THRESHOLD` (currently **3**, defined in `db.py`).
+- Any fetch that returns data resets the counter to 0 via
+  `_record_successful_observation`. One healthy response fully clears
+  the in-flight streak.
+
+Already-`not_listed` rows still increment the counter (as an
+observational log) but don't re-flip or rewrite `notes`.
+
 ### State Diagram
 
 ```mermaid
 stateDiagram-v2
     [*] --> active: register / discover / auto-register
-    active --> not_listed: ensure_keepa_data post-fetch observes empty title + no csv
-    not_listed --> active: manual recovery via update_asin_status after re-listing
+    active --> active: transient fetch_error → log only
+    active --> active: genuine empty, strikes < N → increment counter
+    active --> not_listed: N consecutive genuine empty responses
+    active --> active: any fetch with data → strikes reset to 0
+    not_listed --> active: manual recovery via update_asin_status
 ```
 
 ### Single Write Entry Point

--- a/src/amz_scout/api.py
+++ b/src/amz_scout/api.py
@@ -1021,11 +1021,11 @@ def ensure_keepa_data(
                                 "consecutive empty responses. "
                                 f"Run discover_asin(brand={brand!r}, "
                                 f"model={o.model!r}, marketplace={o.site!r}) "
-                                "for a valid ASIN, or restore via "
-                                f"db.update_asin_status(conn, product_id, "
-                                f"{o.site!r}, 'active') after looking up "
-                                f"product_id with list_products("
-                                f"brand={brand!r}, model={o.model!r})."
+                                "for a valid ASIN, or "
+                                f"update_product_asin(brand={brand!r}, "
+                                f"model={o.model!r}, marketplace={o.site!r}, "
+                                f"asin={o.asin!r}, status='active') "
+                                "if re-listed."
                             )
                         elif was_active and strikes > 0:
                             warnings.append(
@@ -1044,14 +1044,13 @@ def ensure_keepa_data(
                                 f"{o.model} / {o.site} ({o.asin}): "
                                 "Still observed as not_listed "
                                 f"(empty observations: {strikes}). "
-                                f"Restore via db.update_asin_status(conn, "
-                                f"product_id, {o.site!r}, 'active') after "
-                                f"looking up product_id with list_products("
-                                f"brand={brand!r}, model={o.model!r}). "
-                                f"Otherwise run discover_asin("
+                                f"Restore via update_product_asin("
                                 f"brand={brand!r}, model={o.model!r}, "
-                                f"marketplace={o.site!r}) for the correct "
-                                "ASIN."
+                                f"marketplace={o.site!r}, asin={o.asin!r}, "
+                                "status='active') if re-listed. Otherwise "
+                                f"run discover_asin(brand={brand!r}, "
+                                f"model={o.model!r}, marketplace={o.site!r}) "
+                                "for the correct ASIN."
                             )
                         else:
                             # Unregistered ASIN — preserve the legacy

--- a/src/amz_scout/api.py
+++ b/src/amz_scout/api.py
@@ -973,13 +973,30 @@ def ensure_keepa_data(
 
                 for o in fetched_outcomes:
                     ph = o.price_history
-                    fetch_error = ph.fetch_error if ph else ""
                     title = title_map.get((o.asin, o.site), "")
                     has_csv = ph and (
                         ph.buybox_current is not None
                         or ph.new_current is not None
                     )
 
+                    # Defensive: scraper.keepa always returns
+                    # ``_empty_history(..., fetch_error=...)`` for every
+                    # fetched ASIN, but ``keepa_service`` builds outcomes
+                    # via ``history_map.get(pf.asin)`` — a future scraper
+                    # refactor that drops a record would feed ``None``
+                    # here. Treat the missing record as transient (no
+                    # strike, no flip) instead of a "Keepa says ASIN is
+                    # dead" signal.
+                    if ph is None:
+                        warnings.append(
+                            f"{o.model} / {o.site} ({o.asin}): "
+                            "Internal fetch miss (no price_history "
+                            "record); status unchanged, treating as "
+                            "transient."
+                        )
+                        continue
+
+                    fetch_error = ph.fetch_error
                     if fetch_error:
                         # Transient Keepa failure (rate_limited, network,
                         # partial JSON, …). Do NOT touch status or strikes —

--- a/src/amz_scout/api.py
+++ b/src/amz_scout/api.py
@@ -1019,12 +1019,13 @@ def ensure_keepa_data(
                                 f"{o.model} / {o.site} ({o.asin}): "
                                 f"Marked not_listed after {strikes} "
                                 "consecutive empty responses. "
-                                f"Run discover_asin('{brand}', '{o.model}', "
-                                f"'{o.site}') for a valid ASIN, or restore "
-                                "via SQL if re-listed: "
-                                "UPDATE product_asins SET status='active' "
-                                f"WHERE asin='{o.asin}' AND "
-                                f"marketplace='{o.site}'"
+                                f"Run discover_asin(brand={brand!r}, "
+                                f"model={o.model!r}, marketplace={o.site!r}) "
+                                "for a valid ASIN, or restore via "
+                                f"db.update_asin_status(conn, product_id, "
+                                f"{o.site!r}, 'active') after looking up "
+                                f"product_id with list_products("
+                                f"brand={brand!r}, model={o.model!r})."
                             )
                         elif was_active and strikes > 0:
                             warnings.append(
@@ -1043,12 +1044,14 @@ def ensure_keepa_data(
                                 f"{o.model} / {o.site} ({o.asin}): "
                                 "Still observed as not_listed "
                                 f"(empty observations: {strikes}). "
-                                "Restore via SQL if re-listed: "
-                                "UPDATE product_asins SET status='active' "
-                                f"WHERE asin='{o.asin}' AND "
-                                f"marketplace='{o.site}'. Otherwise run "
-                                f"discover_asin('{brand}', '{o.model}', "
-                                f"'{o.site}') for the correct ASIN."
+                                f"Restore via db.update_asin_status(conn, "
+                                f"product_id, {o.site!r}, 'active') after "
+                                f"looking up product_id with list_products("
+                                f"brand={brand!r}, model={o.model!r}). "
+                                f"Otherwise run discover_asin("
+                                f"brand={brand!r}, model={o.model!r}, "
+                                f"marketplace={o.site!r}) for the correct "
+                                "ASIN."
                             )
                         else:
                             # Unregistered ASIN — preserve the legacy
@@ -1057,9 +1060,10 @@ def ensure_keepa_data(
                             warnings.append(
                                 f"{o.model} / {o.site} ({o.asin}): "
                                 "ASIN has no data — likely wrong or not "
-                                "listed. Call discover_asin("
-                                f"'{brand}', '{o.model}', '{o.site}') to "
-                                "search for the correct ASIN."
+                                f"listed. Call discover_asin("
+                                f"brand={brand!r}, model={o.model!r}, "
+                                f"marketplace={o.site!r}) to search for "
+                                "the correct ASIN."
                             )
                         continue
 

--- a/src/amz_scout/api.py
+++ b/src/amz_scout/api.py
@@ -395,29 +395,83 @@ def _auto_fetch_stale_warning(fetch_meta: dict[str, Any]) -> str | None:
     return f"Keepa auto-fetch failed ({detail}); results may be stale."
 
 
-def _try_mark_not_listed(
+def _record_empty_observation(
     conn: sqlite3.Connection,
     asin: str,
     site: str,
-) -> None:
-    """If this ASIN is in the product registry, mark it as not_listed."""
+) -> tuple[int, bool, bool]:
+    """Record a Keepa "no data" observation for a registered ASIN.
+
+    Returns ``(new_strike_count, flipped_to_not_listed,
+    was_active_on_entry)``. Unregistered ASINs are a silent no-op —
+    we only gate rows the user has added to the product registry;
+    they return ``(0, False, False)``.
+
+    The flip to ``not_listed`` only fires when the row is currently
+    ``active`` *and* strikes have reached
+    :data:`amz_scout.db.NOT_LISTED_STRIKE_THRESHOLD`; already-``not_listed``
+    rows still increment their counter but don't rewrite ``notes``.
+    ``was_active_on_entry`` lets callers pick user-facing copy so an
+    already-``not_listed`` row gets an observational-log message
+    instead of the misleading "strike N/THRESHOLD" progression text
+    whose threshold has already been crossed.
+    """
     try:
-        from amz_scout.db import update_asin_status
+        from amz_scout.db import (
+            NOT_LISTED_STRIKE_THRESHOLD,
+            increment_not_listed_strikes,
+            update_asin_status,
+        )
 
         row = conn.execute(
-            "SELECT product_id FROM product_asins WHERE asin = ? AND marketplace = ?",
+            "SELECT product_id, status FROM product_asins "
+            "WHERE asin = ? AND marketplace = ?",
             (asin, site),
         ).fetchone()
-        if row:
+        if not row:
+            return (0, False, False)
+        was_active = row["status"] == "active"
+        strikes = increment_not_listed_strikes(conn, row["product_id"], site)
+        if was_active and strikes >= NOT_LISTED_STRIKE_THRESHOLD:
             update_asin_status(
                 conn,
                 row["product_id"],
                 site,
                 "not_listed",
-                notes="Keepa returned no title or price data",
+                notes=(
+                    f"Keepa returned empty data {strikes}x in a row "
+                    "(transient-failure guard threshold reached)"
+                ),
             )
+            return (strikes, True, was_active)
+        return (strikes, False, was_active)
     except Exception:
-        logger.exception("Failed to mark ASIN %s/%s as not_listed", asin, site)
+        logger.exception(
+            "Failed to record empty observation for ASIN %s/%s", asin, site
+        )
+        return (0, False, False)
+
+
+def _record_successful_observation(
+    conn: sqlite3.Connection,
+    asin: str,
+    site: str,
+) -> None:
+    """Reset the strike counter after a Keepa fetch returned data."""
+    try:
+        from amz_scout.db import clear_not_listed_strikes
+
+        row = conn.execute(
+            "SELECT product_id FROM product_asins "
+            "WHERE asin = ? AND marketplace = ?",
+            (asin, site),
+        ).fetchone()
+        if row:
+            clear_not_listed_strikes(conn, row["product_id"], site)
+    except Exception:
+        logger.exception(
+            "Failed to clear empty-observation strikes for %s/%s", asin, site
+        )
 
 
 def _add_dates(rows: list[dict]) -> list[dict]:
@@ -901,10 +955,14 @@ def ensure_keepa_data(
                 for o in result.outcomes
             ]
 
-            # Post-fetch validation: check for empty/invalid data
+            # Post-fetch validation: branch on transient vs genuine empty.
             warnings: list[str] = []
             fetched_outcomes = [o for o in result.outcomes if o.source == "fetched"]
             if fetched_outcomes:
+                from amz_scout.db import (
+                    NOT_LISTED_STRIKE_THRESHOLD as _STRIKE_THRESHOLD,
+                )
+
                 conds = " OR ".join(["(asin = ? AND site = ?)"] * len(fetched_outcomes))
                 title_params: list = [v for o in fetched_outcomes for v in (o.asin, o.site)]
                 title_rows = conn.execute(
@@ -914,20 +972,78 @@ def ensure_keepa_data(
                 title_map = {(r["asin"], r["site"]): r["title"] or "" for r in title_rows}
 
                 for o in fetched_outcomes:
+                    ph = o.price_history
+                    fetch_error = ph.fetch_error if ph else ""
                     title = title_map.get((o.asin, o.site), "")
-                    has_csv = o.price_history and (
-                        o.price_history.buybox_current is not None
-                        or o.price_history.new_current is not None
+                    has_csv = ph and (
+                        ph.buybox_current is not None
+                        or ph.new_current is not None
                     )
-                    if not title and not has_csv:
-                        brand = o.freshness.brand
+
+                    if fetch_error:
+                        # Transient Keepa failure (rate_limited, network,
+                        # partial JSON, …). Do NOT touch status or strikes —
+                        # a blip must not blacklist a live ASIN.
                         warnings.append(
                             f"{o.model} / {o.site} ({o.asin}): "
-                            "ASIN has no data — likely wrong or not listed. "
-                            f"Call discover_asin('{brand}', '{o.model}', "
-                            f"'{o.site}') to search for the correct ASIN."
+                            f"Transient Keepa failure ({fetch_error}); "
+                            "status unchanged, cached data (if any) "
+                            "still valid."
                         )
-                        _try_mark_not_listed(conn, o.asin, o.site)
+                        continue
+
+                    if not title and not has_csv:
+                        strikes, flipped, was_active = _record_empty_observation(
+                            conn, o.asin, o.site
+                        )
+                        brand = o.freshness.brand
+                        if flipped:
+                            warnings.append(
+                                f"{o.model} / {o.site} ({o.asin}): "
+                                f"Marked not_listed after {strikes} "
+                                "consecutive empty responses. "
+                                f"Run discover_asin('{brand}', '{o.model}', "
+                                f"'{o.site}') for a valid ASIN, or "
+                                "update_asin_status(status='active') if "
+                                "re-listed."
+                            )
+                        elif was_active and strikes > 0:
+                            warnings.append(
+                                f"{o.model} / {o.site} ({o.asin}): "
+                                f"Empty Keepa response (strike {strikes}/"
+                                f"{_STRIKE_THRESHOLD}); status unchanged. "
+                                "Will mark not_listed after consecutive "
+                                "threshold."
+                            )
+                        elif strikes > 0:
+                            # Already not_listed: observational log only —
+                            # no "strike N/threshold" progression copy
+                            # whose threshold has already been crossed.
+                            warnings.append(
+                                f"{o.model} / {o.site} ({o.asin}): "
+                                "Still observed as not_listed "
+                                f"(empty observations: {strikes}). "
+                                "Use update_asin_status(status='active') "
+                                "if re-listed, or discover_asin("
+                                f"'{brand}', '{o.model}', '{o.site}') "
+                                "for the correct ASIN."
+                            )
+                        else:
+                            # Unregistered ASIN — preserve the legacy
+                            # actionable warning for operators pasting
+                            # bad ASINs directly.
+                            warnings.append(
+                                f"{o.model} / {o.site} ({o.asin}): "
+                                "ASIN has no data — likely wrong or not "
+                                "listed. Call discover_asin("
+                                f"'{brand}', '{o.model}', '{o.site}') to "
+                                "search for the correct ASIN."
+                            )
+                        continue
+
+                    # Fetch returned data — reset any in-flight strike
+                    # streak so one healthy response fully clears history.
+                    _record_successful_observation(conn, o.asin, o.site)
 
     except ValueError as e:
         logger.warning("ensure_keepa_data: %s", e)

--- a/src/amz_scout/api.py
+++ b/src/amz_scout/api.py
@@ -1020,17 +1020,20 @@ def ensure_keepa_data(
                                 f"Marked not_listed after {strikes} "
                                 "consecutive empty responses. "
                                 f"Run discover_asin('{brand}', '{o.model}', "
-                                f"'{o.site}') for a valid ASIN, or "
-                                "update_asin_status(status='active') if "
-                                "re-listed."
+                                f"'{o.site}') for a valid ASIN, or restore "
+                                "via SQL if re-listed: "
+                                "UPDATE product_asins SET status='active' "
+                                f"WHERE asin='{o.asin}' AND "
+                                f"marketplace='{o.site}'"
                             )
                         elif was_active and strikes > 0:
                             warnings.append(
                                 f"{o.model} / {o.site} ({o.asin}): "
                                 f"Empty Keepa response (strike {strikes}/"
                                 f"{_STRIKE_THRESHOLD}); status unchanged. "
-                                "Will mark not_listed after consecutive "
-                                "threshold."
+                                f"Will mark not_listed after "
+                                f"{_STRIKE_THRESHOLD} consecutive genuine "
+                                "empty responses."
                             )
                         elif strikes > 0:
                             # Already not_listed: observational log only —
@@ -1040,10 +1043,12 @@ def ensure_keepa_data(
                                 f"{o.model} / {o.site} ({o.asin}): "
                                 "Still observed as not_listed "
                                 f"(empty observations: {strikes}). "
-                                "Use update_asin_status(status='active') "
-                                "if re-listed, or discover_asin("
-                                f"'{brand}', '{o.model}', '{o.site}') "
-                                "for the correct ASIN."
+                                "Restore via SQL if re-listed: "
+                                "UPDATE product_asins SET status='active' "
+                                f"WHERE asin='{o.asin}' AND "
+                                f"marketplace='{o.site}'. Otherwise run "
+                                f"discover_asin('{brand}', '{o.model}', "
+                                f"'{o.site}') for the correct ASIN."
                             )
                         else:
                             # Unregistered ASIN — preserve the legacy

--- a/src/amz_scout/db.py
+++ b/src/amz_scout/db.py
@@ -103,7 +103,13 @@ SERIES_NAMES = {
     100: "MONTHLY_SOLD",
 }
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
+
+# Consecutive-empty counter threshold before flipping product_asins.status
+# to 'not_listed'. A single transient Keepa failure (rate_limited, network
+# blip, partial JSON) must not blacklist a live ASIN, so genuine "Keepa
+# knows nothing" observations are required in a row before the flip.
+NOT_LISTED_STRIKE_THRESHOLD = 3
 
 # ─── Connection management ────────────────────────────────────────────
 
@@ -463,6 +469,35 @@ def _migrate(conn: sqlite3.Connection) -> None:
         # failure and silently skip the v7 migration forever.
         if not v7_applied:
             _migrate_to_v7(conn)
+
+        # v9 must run AFTER v7 commits, in its own ``with conn:`` so the
+        # INSERT into schema_migrations is committed before init_schema
+        # returns. Without the wrap, Python sqlite3 would leave an
+        # implicit transaction open and ``conn.close()`` callers (e.g.
+        # ``get_connection``) would silently roll it back. ALTER TABLE
+        # (DDL) auto-commits in SQLite regardless, but the
+        # schema_migrations row needs the wrap. (PR #20 review feedback.)
+        if current < 9:
+            with conn:
+                # v9: transient-failure guard — add a consecutive-empty
+                # counter so a single Keepa blip can't permanently
+                # blacklist a live ASIN (issue #11).
+                cols = [
+                    r["name"]
+                    for r in conn.execute("PRAGMA table_info(product_asins)")
+                ]
+                if "not_listed_strikes" not in cols:
+                    conn.execute(
+                        "ALTER TABLE product_asins "
+                        "ADD COLUMN not_listed_strikes "
+                        "INTEGER NOT NULL DEFAULT 0"
+                    )
+                conn.execute(
+                    "INSERT OR IGNORE INTO schema_migrations "
+                    "(version, description) VALUES "
+                    "(9, 'add not_listed_strikes counter to product_asins')"
+                )
+                logger.info("Migrated schema to version 9")
     except Exception:
         logger.exception(
             "Schema migration failed at version %d. Database may need manual repair.",
@@ -623,6 +658,8 @@ INSERT INTO schema_migrations (version, description)
     VALUES (7, 'normalize brand/model matching via brand_key/model_key');
 INSERT INTO schema_migrations (version, description)
     VALUES (8, 'canonicalize ean_list/upc_list to GTIN-13');
+INSERT INTO schema_migrations (version, description)
+    VALUES (9, 'add not_listed_strikes counter to product_asins');
 
 CREATE TABLE competitive_snapshots (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -792,6 +829,9 @@ CREATE TABLE product_asins (
                     CHECK(status IN ('active', 'not_listed')),
     notes           TEXT NOT NULL DEFAULT '',
     last_checked    TEXT,
+    -- Consecutive-empty counter (transient-failure guard; since v8).
+    -- Flip to not_listed only at NOT_LISTED_STRIKE_THRESHOLD.
+    not_listed_strikes INTEGER NOT NULL DEFAULT 0,
     created_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
     updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
     PRIMARY KEY (product_id, marketplace)
@@ -1963,6 +2003,56 @@ def update_asin_status(
             "updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') "
             "WHERE product_id = ? AND marketplace = ?",
             (status, notes, product_id, marketplace),
+        )
+
+
+def increment_not_listed_strikes(
+    conn: sqlite3.Connection,
+    product_id: int,
+    marketplace: str,
+) -> int:
+    """Increment the consecutive-empty strike counter. Returns the new value.
+
+    Does NOT flip ``status``. Callers that cross
+    :data:`NOT_LISTED_STRIKE_THRESHOLD` should follow up with
+    :func:`update_asin_status` so ``last_checked`` bookkeeping stays
+    consistent with other status transitions.
+    """
+    with conn:
+        conn.execute(
+            "UPDATE product_asins SET "
+            "not_listed_strikes = not_listed_strikes + 1, "
+            "updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') "
+            "WHERE product_id = ? AND marketplace = ?",
+            (product_id, marketplace),
+        )
+        row = conn.execute(
+            "SELECT not_listed_strikes FROM product_asins "
+            "WHERE product_id = ? AND marketplace = ?",
+            (product_id, marketplace),
+        ).fetchone()
+    return int(row["not_listed_strikes"]) if row else 0
+
+
+def clear_not_listed_strikes(
+    conn: sqlite3.Connection,
+    product_id: int,
+    marketplace: str,
+) -> None:
+    """Reset the consecutive-empty strike counter to 0.
+
+    Called on any fetch that returns a non-empty title or csv. The
+    ``not_listed_strikes != 0`` guard avoids ``updated_at`` churn on
+    the hot "still 0" path.
+    """
+    with conn:
+        conn.execute(
+            "UPDATE product_asins SET "
+            "not_listed_strikes = 0, "
+            "updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') "
+            "WHERE product_id = ? AND marketplace = ? "
+            "AND not_listed_strikes != 0",
+            (product_id, marketplace),
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1100,3 +1100,300 @@ class TestResolveAsinStatusGate:
         assert r["ok"] is False
         assert "not_listed" in r["error"]
         assert r["data"] == []
+
+
+# ─── Transient-failure guard (issue #11) ─────────────────────────────
+
+
+class TestEmptyObservationStrikes:
+    """Strike counter behaviour for _record_empty_observation.
+
+    Covers the internal state machine: unregistered ASIN no-op,
+    incremental counting, threshold flip, and reset-on-success.
+    """
+
+    def _seed(self, tmp_path, asin="B0STRIKE01", status="active"):
+        db_path = tmp_path / "strikes.db"
+        c = sqlite3.connect(str(db_path))
+        c.row_factory = sqlite3.Row
+        init_schema(c)
+        pid, _ = register_product(c, "Router", "BrandX", "ModelX")
+        register_asin(c, pid, "UK", asin, status=status, notes="")
+        return c, pid
+
+    def test_unregistered_asin_is_noop(self, tmp_path):
+        from amz_scout.api import _record_empty_observation
+
+        c, _ = self._seed(tmp_path)
+        strikes, flipped, was_active = _record_empty_observation(
+            c, "B0UNREG0001", "UK"
+        )
+        assert (strikes, flipped, was_active) == (0, False, False)
+        c.close()
+
+    def test_first_empty_increments_only(self, tmp_path):
+        from amz_scout.api import _record_empty_observation
+
+        c, pid = self._seed(tmp_path)
+        strikes, flipped, was_active = _record_empty_observation(
+            c, "B0STRIKE01", "UK"
+        )
+        assert strikes == 1
+        assert flipped is False
+        assert was_active is True
+        row = c.execute(
+            "SELECT status, not_listed_strikes FROM product_asins "
+            "WHERE product_id = ? AND marketplace = 'UK'",
+            (pid,),
+        ).fetchone()
+        assert row["status"] == "active"
+        assert row["not_listed_strikes"] == 1
+        c.close()
+
+    def test_threshold_flips_to_not_listed(self, tmp_path):
+        from amz_scout.api import _record_empty_observation
+        from amz_scout.db import NOT_LISTED_STRIKE_THRESHOLD
+
+        c, pid = self._seed(tmp_path)
+        for _ in range(NOT_LISTED_STRIKE_THRESHOLD - 1):
+            _record_empty_observation(c, "B0STRIKE01", "UK")
+        strikes, flipped, was_active = _record_empty_observation(
+            c, "B0STRIKE01", "UK"
+        )
+        assert strikes == NOT_LISTED_STRIKE_THRESHOLD
+        assert flipped is True
+        # The threshold-crossing call itself saw the row as ``active``
+        # — ``was_active_on_entry`` captures pre-flip state.
+        assert was_active is True
+        row = c.execute(
+            "SELECT status FROM product_asins "
+            "WHERE product_id = ? AND marketplace = 'UK'",
+            (pid,),
+        ).fetchone()
+        assert row["status"] == "not_listed"
+        c.close()
+
+    def test_successful_observation_resets_strikes(self, tmp_path):
+        from amz_scout.api import (
+            _record_empty_observation,
+            _record_successful_observation,
+        )
+
+        c, pid = self._seed(tmp_path)
+        _record_empty_observation(c, "B0STRIKE01", "UK")
+        _record_empty_observation(c, "B0STRIKE01", "UK")
+        _record_successful_observation(c, "B0STRIKE01", "UK")
+        row = c.execute(
+            "SELECT not_listed_strikes FROM product_asins "
+            "WHERE product_id = ? AND marketplace = 'UK'",
+            (pid,),
+        ).fetchone()
+        assert row["not_listed_strikes"] == 0
+        c.close()
+
+    def test_already_not_listed_does_not_flip(self, tmp_path):
+        """Already-not_listed rows still count strikes but don't re-flip.
+
+        Intended side-effect: ``flipped=False`` protects us from
+        rewriting ``notes`` every fetch, while ``strikes`` keeps
+        accumulating as an observational log. ``was_active_on_entry``
+        is False so callers can pick log-style copy instead of
+        "strike N/THRESHOLD" progression text.
+        """
+        from amz_scout.api import _record_empty_observation
+
+        c, _ = self._seed(tmp_path, status="not_listed")
+        strikes, flipped, was_active = _record_empty_observation(
+            c, "B0STRIKE01", "UK"
+        )
+        assert flipped is False
+        assert strikes == 1
+        assert was_active is False
+        c.close()
+
+
+class TestEnsureKeepaDataTransientVsPermanent:
+    """End-to-end: ensure_keepa_data distinguishes transient from genuine empty."""
+
+    def _register(self, tmp_path, asin, status="active"):
+        db_path = tmp_path / "output" / "amz_scout.db"
+        c = sqlite3.connect(str(db_path))
+        c.row_factory = sqlite3.Row
+        pid, _ = register_product(c, "Router", "BrandY", "ModelY")
+        register_asin(c, pid, "UK", asin, status=status, notes="")
+        c.close()
+        return db_path, pid
+
+    @staticmethod
+    def _make_outcome(asin, site, fetch_error=""):
+        from amz_scout.freshness import ProductFreshness
+        from amz_scout.keepa_service import KeepaProductOutcome
+        from amz_scout.models import PriceHistory
+
+        pf = ProductFreshness(
+            asin=asin,
+            site=site,
+            model="ModelY",
+            brand="BrandY",
+            fetched_at=None,
+            age_days=None,
+            action="fetch",
+            reason="test-fixture",
+        )
+        ph = PriceHistory(
+            date="2026-04-21",
+            site=site,
+            category="Router",
+            brand="BrandY",
+            model="ModelY",
+            asin=asin,
+            fetch_error=fetch_error,
+        )
+        return KeepaProductOutcome(
+            asin=asin,
+            site=site,
+            model="ModelY",
+            source="fetched",
+            price_history=ph,
+            freshness=pf,
+        )
+
+    def test_transient_blip_preserves_status(self, config_dir, monkeypatch):
+        """fetch_error != '' must not touch status or strikes."""
+        from amz_scout.keepa_service import KeepaResult
+
+        tmp_path, proj_path = config_dir
+        db_path, _pid = self._register(tmp_path, "B0TRANS0001", status="active")
+
+        def fake_get_keepa_data(conn, products, sites, marketplaces, **_kw):
+            return KeepaResult(
+                outcomes=[self._make_outcome("B0TRANS0001", "UK", "rate_limited")],
+                tokens_used=0,
+                tokens_remaining=60,
+            )
+
+        monkeypatch.setattr(
+            "amz_scout.keepa_service.get_keepa_data", fake_get_keepa_data
+        )
+        r = ensure_keepa_data(proj_path, marketplace="UK", confirm=True)
+        assert r["ok"] is True
+
+        c = sqlite3.connect(str(db_path))
+        c.row_factory = sqlite3.Row
+        row = c.execute(
+            "SELECT status, not_listed_strikes FROM product_asins "
+            "WHERE asin = 'B0TRANS0001' AND marketplace = 'UK'"
+        ).fetchone()
+        assert row["status"] == "active"
+        assert row["not_listed_strikes"] == 0
+        warnings = r["meta"].get("warnings", [])
+        assert any("Transient Keepa failure" in w for w in warnings), warnings
+        c.close()
+
+    def test_genuine_empty_increments_strike_under_threshold(
+        self, config_dir, monkeypatch
+    ):
+        """fetch_error='' + empty body → strike counter bumps, status stays."""
+        from amz_scout.keepa_service import KeepaResult
+
+        tmp_path, proj_path = config_dir
+        db_path, _pid = self._register(tmp_path, "B0EMPTY0001", status="active")
+
+        def fake_get_keepa_data(conn, products, sites, marketplaces, **_kw):
+            return KeepaResult(
+                outcomes=[self._make_outcome("B0EMPTY0001", "UK", "")],
+                tokens_used=0,
+                tokens_remaining=60,
+            )
+
+        monkeypatch.setattr(
+            "amz_scout.keepa_service.get_keepa_data", fake_get_keepa_data
+        )
+        r = ensure_keepa_data(proj_path, marketplace="UK", confirm=True)
+        assert r["ok"] is True
+
+        c = sqlite3.connect(str(db_path))
+        c.row_factory = sqlite3.Row
+        row = c.execute(
+            "SELECT status, not_listed_strikes FROM product_asins "
+            "WHERE asin = 'B0EMPTY0001' AND marketplace = 'UK'"
+        ).fetchone()
+        assert row["status"] == "active"
+        assert row["not_listed_strikes"] == 1
+        warnings = r["meta"].get("warnings", [])
+        assert any("strike 1/" in w for w in warnings), warnings
+        c.close()
+
+    def test_already_not_listed_emits_observational_log_copy(
+        self, config_dir, monkeypatch
+    ):
+        """Re-fetching an already-not_listed ASIN must NOT emit
+        'strike N/THRESHOLD; will mark not_listed after consecutive
+        threshold' — the threshold has already been crossed, so that
+        copy is misleading. Instead, emit a log-style message.
+        """
+        from amz_scout.keepa_service import KeepaResult
+
+        tmp_path, proj_path = config_dir
+        db_path, _pid = self._register(
+            tmp_path, "B0DELIST001", status="not_listed"
+        )
+
+        def fake_get_keepa_data(conn, products, sites, marketplaces, **_kw):
+            return KeepaResult(
+                outcomes=[self._make_outcome("B0DELIST001", "UK", "")],
+                tokens_used=0,
+                tokens_remaining=60,
+            )
+
+        monkeypatch.setattr(
+            "amz_scout.keepa_service.get_keepa_data", fake_get_keepa_data
+        )
+        r = ensure_keepa_data(proj_path, marketplace="UK", confirm=True)
+        assert r["ok"] is True
+
+        c = sqlite3.connect(str(db_path))
+        c.row_factory = sqlite3.Row
+        row = c.execute(
+            "SELECT status, not_listed_strikes FROM product_asins "
+            "WHERE asin = 'B0DELIST001' AND marketplace = 'UK'"
+        ).fetchone()
+        # Status unchanged; strikes still advance as observational log.
+        assert row["status"] == "not_listed"
+        assert row["not_listed_strikes"] == 1
+        warnings = r["meta"].get("warnings", [])
+        # Observational-log copy, NOT progression copy.
+        assert any(
+            "Still observed as not_listed" in w for w in warnings
+        ), warnings
+        assert not any("strike 1/" in w for w in warnings), warnings
+        assert not any(
+            "Will mark not_listed after consecutive threshold" in w
+            for w in warnings
+        ), warnings
+        c.close()
+
+
+class TestAsinStatusRecovery:
+    """Manual not_listed -> active recovery via update_asin_status (issue #11)."""
+
+    def test_update_asin_status_restores_active(self, tmp_path):
+        from amz_scout.api import _resolve_asin
+        from amz_scout.db import update_asin_status
+
+        db_path = tmp_path / "recovery.db"
+        c = sqlite3.connect(str(db_path))
+        c.row_factory = sqlite3.Row
+        init_schema(c)
+        pid, _ = register_product(c, "Router", "B", "M")
+        register_asin(c, pid, "UK", "B0RECOV001", status="not_listed", notes="")
+
+        with pytest.raises(ValueError, match="not_listed"):
+            _resolve_asin([], "B0RECOV001", marketplace="UK", conn=c)
+
+        update_asin_status(
+            c, pid, "UK", "active", notes="operator confirmed re-listed"
+        )
+        asin, *_ = _resolve_asin([], "B0RECOV001", marketplace="UK", conn=c)
+        assert asin == "B0RECOV001"
+        c.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1324,6 +1324,67 @@ class TestEnsureKeepaDataTransientVsPermanent:
         assert any("strike 1/" in w for w in warnings), warnings
         c.close()
 
+    def test_missing_price_history_treated_as_transient(
+        self, config_dir, monkeypatch
+    ):
+        """Copilot review (PR #20): KeepaProductOutcome with
+        ``source='fetched'`` + ``price_history=None`` must NOT
+        increment strikes — it's an internal fetch miss (scraper
+        dropped a record), not a "Keepa says ASIN is dead" signal.
+        """
+        from amz_scout.freshness import ProductFreshness
+        from amz_scout.keepa_service import KeepaProductOutcome, KeepaResult
+
+        tmp_path, proj_path = config_dir
+        db_path, _pid = self._register(
+            tmp_path, "B0MISSNG001", status="active"
+        )
+
+        pf = ProductFreshness(
+            asin="B0MISSNG001",
+            site="UK",
+            model="ModelY",
+            brand="BrandY",
+            fetched_at=None,
+            age_days=None,
+            action="fetch",
+            reason="test-fixture",
+        )
+        outcome = KeepaProductOutcome(
+            asin="B0MISSNG001",
+            site="UK",
+            model="ModelY",
+            source="fetched",
+            price_history=None,  # ← scraper miss
+            freshness=pf,
+        )
+
+        def fake_get_keepa_data(conn, products, sites, marketplaces, **_kw):
+            return KeepaResult(
+                outcomes=[outcome],
+                tokens_used=0,
+                tokens_remaining=60,
+            )
+
+        monkeypatch.setattr(
+            "amz_scout.keepa_service.get_keepa_data", fake_get_keepa_data
+        )
+        r = ensure_keepa_data(proj_path, marketplace="UK", confirm=True)
+        assert r["ok"] is True
+
+        c = sqlite3.connect(str(db_path))
+        c.row_factory = sqlite3.Row
+        row = c.execute(
+            "SELECT status, not_listed_strikes FROM product_asins "
+            "WHERE asin = 'B0MISSNG001' AND marketplace = 'UK'"
+        ).fetchone()
+        # Status preserved, strikes NOT incremented.
+        assert row["status"] == "active"
+        assert row["not_listed_strikes"] == 0
+        warnings = r["meta"].get("warnings", [])
+        assert any("Internal fetch miss" in w for w in warnings), warnings
+        c.close()
+
     def test_already_not_listed_emits_observational_log_copy(
         self, config_dir, monkeypatch
     ):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -739,7 +739,7 @@ class TestBrandModelKeyMigrationV7:
         ver = c2.execute(
             "SELECT MAX(version) AS v FROM schema_migrations"
         ).fetchone()["v"]
-        assert ver == 8
+        assert ver == 9
 
         with pytest.raises(sqlite3.IntegrityError):
             c2.execute(
@@ -1194,7 +1194,10 @@ class TestGtinBackfillMigrationV8:
         c0 = sqlite3.connect(str(db_path))
         c0.row_factory = sqlite3.Row
         init_schema(c0)
-        c0.execute("DELETE FROM schema_migrations WHERE version = 8")
+        # Drop v8+ records so MAX(version)=7 and the v8 backfill actually
+        # reruns on reopen. (Just deleting v8 leaves MAX=9 from the v9
+        # not_listed_strikes record, which short-circuits _migrate.)
+        c0.execute("DELETE FROM schema_migrations WHERE version >= 8")
         c0.execute(
             "INSERT INTO keepa_products "
             "(asin, site, brand, ean_list, upc_list, "
@@ -1232,7 +1235,7 @@ class TestGtinBackfillMigrationV8:
                     "SELECT MAX(version) AS v FROM schema_migrations"
                 ).fetchone()["v"]
 
-        assert version == 8
+        assert version == 9
         assert json.loads(us["upc_list"]) == ["0850018166010"]
         assert us["ean_list"] is None
         assert json.loads(eu["ean_list"]) == ["0850018166010"]
@@ -1264,7 +1267,10 @@ class TestGtinBackfillMigrationV8:
         c0 = sqlite3.connect(str(db_path))
         c0.row_factory = sqlite3.Row
         init_schema(c0)
-        c0.execute("DELETE FROM schema_migrations WHERE version = 8")
+        # Drop v8+ records so MAX(version)=7 and the v8 backfill actually
+        # reruns on reopen. (Just deleting v8 leaves MAX=9 from the v9
+        # not_listed_strikes record, which short-circuits _migrate.)
+        c0.execute("DELETE FROM schema_migrations WHERE version >= 8")
         c0.execute(
             "INSERT INTO keepa_products "
             "(asin, site, brand, ean_list, upc_list, "
@@ -1340,12 +1346,12 @@ class TestV7RetryAfterV8Commit:
         c0.execute("PRAGMA foreign_keys = ON")
         c0.commit()
 
-        # Sanity: without the fix, current = MAX(version) = 8 would
+        # Sanity: without the fix, current = MAX(version) >= 8 would
         # bypass v7 on reopen.
         max_ver = c0.execute(
             "SELECT MAX(version) AS v FROM schema_migrations"
         ).fetchone()["v"]
-        assert max_ver == 8
+        assert max_ver == 9
         c0.close()
 
         db_mod._schema_initialized.discard(str(db_path))
@@ -1485,16 +1491,18 @@ class TestRegisterProductConcurrency:
 # ─── Migration ordering: v8 must wait for v7 (Copilot PR #20) ────────
 
 
-class TestMigrationOrderingV8AfterV7:
+class TestMigrationOrderingV9AfterV7:
     """Regression guard for the schema_migrations stranding bug.
 
-    If v8 is recorded *before* v7 commits, a v7 failure leaves the DB
-    at MAX(version)=8 with v7 un-applied. The next ``init_schema()``
+    If v9 is recorded *before* v7 commits, a v7 failure leaves the DB
+    at MAX(version)=9 with v7 un-applied. The next ``init_schema()``
     short-circuits on ``current >= SCHEMA_VERSION`` and never retries
-    v7 — silent permanent corruption.
+    v7 — silent permanent corruption. (Note: main has its own v8 ↔ v7
+    safety via the ``v7_applied`` flag in ``_migrate``; v9 sits after
+    v7 in the migration sequence and is gated by ``current < 9``.)
     """
 
-    def test_v7_failure_does_not_strand_v8_record(self, tmp_path, monkeypatch):
+    def test_v7_failure_does_not_strand_v9_record(self, tmp_path, monkeypatch):
         from amz_scout import db as db_mod
 
         db_path = tmp_path / "ordering.db"
@@ -1528,17 +1536,19 @@ class TestMigrationOrderingV8AfterV7:
             for r in c1.execute("SELECT version FROM schema_migrations")
         }
         assert 7 not in versions, "v7 record must not appear after raise"
-        assert 8 not in versions, (
-            "v8 record must not appear if v7 hasn't completed — "
-            "otherwise MAX(version)=8 would block v7 retry forever"
+        assert 9 not in versions, (
+            "v9 record must not appear if v7 hasn't completed — "
+            "v9 runs after v7 and must not be stranded by a v7 failure. "
+            "(v8 is in the main txn and may already be present — that "
+            "is main's existing GTIN migration, unrelated to v7 ordering.)"
         )
         c1.close()
 
-    def test_v7_recovery_after_failure_completes_to_v8(
+    def test_v7_recovery_after_failure_completes_to_v9(
         self, tmp_path, monkeypatch
     ):
         """After a v7 failure, removing the patch must let init_schema
-        complete v7 AND v8 cleanly on the next call.
+        complete v7 AND v9 cleanly on the next call.
         """
         from amz_scout import db as db_mod
 
@@ -1578,10 +1588,10 @@ class TestMigrationOrderingV8AfterV7:
         max_v = c2.execute(
             "SELECT MAX(version) AS v FROM schema_migrations"
         ).fetchone()["v"]
-        assert max_v == 8
+        assert max_v == 9
         c2.close()
 
-    def test_v8_persisted_across_connection_close(self, tmp_path):
+    def test_v9_persisted_across_connection_close(self, tmp_path):
         """Copilot follow-up review on PR #20: the v8 block runs outside
         any ``with conn:`` block, so its INSERT into ``schema_migrations``
         is in an open implicit transaction when ``init_schema`` returns.
@@ -1620,10 +1630,10 @@ class TestMigrationOrderingV8AfterV7:
             r[1] for r in c2.execute("PRAGMA table_info(product_asins)")
         ]
         assert 7 in versions, "v7 record must survive close without commit"
-        assert 8 in versions, (
-            "v8 record must survive close without commit. v8 INSERT runs "
-            "outside any ``with conn:`` and gets rolled back on close — "
-            "wrap the v8 block in its own ``with conn:`` to fix."
+        assert 9 in versions, (
+            "v9 record must survive close without commit. v9 INSERT runs "
+            "outside the main txn and gets rolled back on close unless "
+            "wrapped in its own ``with conn:`` — that wrap is the fix."
         )
         assert "not_listed_strikes" in cols, (
             "ALTER TABLE (DDL) auto-commits in SQLite, so the column "

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1480,3 +1480,103 @@ class TestRegisterProductConcurrency:
         assert (row["brand"], row["model"]) in variants
         assert row["brand_key"] == "tp-link"
         assert row["model_key"] == "archer be400"
+
+
+# ─── Migration ordering: v8 must wait for v7 (Copilot PR #20) ────────
+
+
+class TestMigrationOrderingV8AfterV7:
+    """Regression guard for the schema_migrations stranding bug.
+
+    If v8 is recorded *before* v7 commits, a v7 failure leaves the DB
+    at MAX(version)=8 with v7 un-applied. The next ``init_schema()``
+    short-circuits on ``current >= SCHEMA_VERSION`` and never retries
+    v7 — silent permanent corruption.
+    """
+
+    def test_v7_failure_does_not_strand_v8_record(self, tmp_path, monkeypatch):
+        from amz_scout import db as db_mod
+
+        db_path = tmp_path / "ordering.db"
+        c0 = sqlite3.connect(str(db_path))
+        c0.row_factory = sqlite3.Row
+        init_schema(c0)
+        # Force schema_migrations back to MAX(version)=6 so the v7 + v8
+        # paths both rerun on next open. (Underlying tables are already
+        # at v8 shape — that's fine; v8's ALTER is column-existence
+        # guarded and v7 is monkey-patched out.)
+        c0.execute("DELETE FROM schema_migrations WHERE version >= 7")
+        c0.commit()
+        c0.close()
+        # init_schema caches db_paths it has fully migrated and short-
+        # circuits on cache hit. Clear that one entry so the next open
+        # actually re-runs _migrate (where the patched v7 lives).
+        db_mod._schema_initialized.discard(str(db_path))
+
+        def fake_migrate_v7(_conn):
+            raise RuntimeError("simulated v7 failure")
+
+        monkeypatch.setattr(db_mod, "_migrate_to_v7", fake_migrate_v7)
+
+        c1 = sqlite3.connect(str(db_path))
+        c1.row_factory = sqlite3.Row
+        with pytest.raises(RuntimeError, match="simulated v7"):
+            init_schema(c1)
+
+        versions = {
+            r["version"]
+            for r in c1.execute("SELECT version FROM schema_migrations")
+        }
+        assert 7 not in versions, "v7 record must not appear after raise"
+        assert 8 not in versions, (
+            "v8 record must not appear if v7 hasn't completed — "
+            "otherwise MAX(version)=8 would block v7 retry forever"
+        )
+        c1.close()
+
+    def test_v7_recovery_after_failure_completes_to_v8(
+        self, tmp_path, monkeypatch
+    ):
+        """After a v7 failure, removing the patch must let init_schema
+        complete v7 AND v8 cleanly on the next call.
+        """
+        from amz_scout import db as db_mod
+
+        db_path = tmp_path / "recovery.db"
+        c0 = sqlite3.connect(str(db_path))
+        c0.row_factory = sqlite3.Row
+        init_schema(c0)
+        c0.execute("DELETE FROM schema_migrations WHERE version >= 7")
+        c0.commit()
+        c0.close()
+        db_mod._schema_initialized.discard(str(db_path))
+
+        original_v7 = db_mod._migrate_to_v7
+
+        def fake_migrate_v7(_conn):
+            raise RuntimeError("simulated v7 failure")
+
+        monkeypatch.setattr(db_mod, "_migrate_to_v7", fake_migrate_v7)
+
+        c1 = sqlite3.connect(str(db_path))
+        c1.row_factory = sqlite3.Row
+        with pytest.raises(RuntimeError):
+            init_schema(c1)
+        c1.close()
+
+        # init_schema doesn't add to the cache when _migrate raises (the
+        # ``_schema_initialized.add(...)`` is unreachable past the
+        # exception), so we don't strictly need a discard before c2 — but
+        # clear it anyway in case future refactors flip the order.
+        db_mod._schema_initialized.discard(str(db_path))
+
+        # Restore real v7 and reopen — both v7 and v8 should now apply.
+        monkeypatch.setattr(db_mod, "_migrate_to_v7", original_v7)
+        c2 = sqlite3.connect(str(db_path))
+        c2.row_factory = sqlite3.Row
+        init_schema(c2)
+        max_v = c2.execute(
+            "SELECT MAX(version) AS v FROM schema_migrations"
+        ).fetchone()["v"]
+        assert max_v == 8
+        c2.close()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1580,3 +1580,53 @@ class TestMigrationOrderingV8AfterV7:
         ).fetchone()["v"]
         assert max_v == 8
         c2.close()
+
+    def test_v8_persisted_across_connection_close(self, tmp_path):
+        """Copilot follow-up review on PR #20: the v8 block runs outside
+        any ``with conn:`` block, so its INSERT into ``schema_migrations``
+        is in an open implicit transaction when ``init_schema`` returns.
+        If the caller (e.g. ``get_connection``) closes the connection
+        without ``commit()``, Python sqlite3 rolls back the open tx and
+        the v8 record is silently lost — even though ``ALTER TABLE`` (a
+        DDL) was already auto-committed by SQLite. The next reopen would
+        then see ``MAX(version)=7`` with the column already present, and
+        re-run the v8 block on every open. v8 must commit on its own.
+        """
+        from amz_scout import db as db_mod
+
+        db_path = tmp_path / "persist.db"
+        c0 = sqlite3.connect(str(db_path))
+        c0.row_factory = sqlite3.Row
+        init_schema(c0)
+        # Force back to v6 so v7 + v8 both rerun on reopen.
+        c0.execute("DELETE FROM schema_migrations WHERE version >= 7")
+        c0.commit()
+        c0.close()
+        db_mod._schema_initialized.discard(str(db_path))
+
+        # Reopen and run init_schema, then close WITHOUT explicit commit
+        # — exactly what ``get_connection`` does in production.
+        c1 = sqlite3.connect(str(db_path))
+        c1.row_factory = sqlite3.Row
+        init_schema(c1)
+        c1.close()  # No commit() — caller pattern.
+
+        c2 = sqlite3.connect(str(db_path))
+        c2.row_factory = sqlite3.Row
+        versions = {
+            r[0] for r in c2.execute("SELECT version FROM schema_migrations")
+        }
+        cols = [
+            r[1] for r in c2.execute("PRAGMA table_info(product_asins)")
+        ]
+        assert 7 in versions, "v7 record must survive close without commit"
+        assert 8 in versions, (
+            "v8 record must survive close without commit. v8 INSERT runs "
+            "outside any ``with conn:`` and gets rolled back on close — "
+            "wrap the v8 block in its own ``with conn:`` to fix."
+        )
+        assert "not_listed_strikes" in cols, (
+            "ALTER TABLE (DDL) auto-commits in SQLite, so the column "
+            "should always survive — but assert it anyway as a sanity check."
+        )
+        c2.close()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -62,11 +62,11 @@ class TestSchema:
     def test_init_schema_idempotent(self, conn):
         init_schema(conn)  # Second call should not raise
         row = conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()
-        assert row[0] == 8  # v1..v8
+        assert row[0] == 9  # v1..v9 inclusive
 
     def test_schema_version(self, conn):
         row = conn.execute("SELECT MAX(version) FROM schema_migrations").fetchone()
-        assert row[0] == 8
+        assert row[0] == 9
 
 
 # ─── Keepa write tests ──────────────────────────────────────────────
@@ -427,10 +427,13 @@ class TestStatusMigrationV6:
         c0 = sqlite3.connect(str(db_path))
         c0.row_factory = sqlite3.Row
         init_schema(c0)
-        # Drop v6, v7, *and* v8 records so MAX(version)=5 and the v6
-        # migration path actually runs on reopen. (v7/v8 records are
-        # seeded by _SCHEMA_SQL even for a "fresh v5 downgrade".)
-        c0.execute("DELETE FROM schema_migrations WHERE version IN (6, 7, 8)")
+        # Drop v6+ records so MAX(version)=5 and the v6 migration path
+        # actually runs on reopen. (Every version record is seeded by
+        # _SCHEMA_SQL even for a "fresh v5 downgrade" — so later
+        # migrations like v7/v8/v9 must be dropped too, otherwise
+        # _migrate short-circuits on its `current >= SCHEMA_VERSION`
+        # check.)
+        c0.execute("DELETE FROM schema_migrations WHERE version >= 6")
         c0.execute("ALTER TABLE product_asins RENAME TO _pa_tmp")
         c0.execute("""
             CREATE TABLE product_asins (
@@ -452,7 +455,17 @@ class TestStatusMigrationV6:
                 PRIMARY KEY (product_id, marketplace)
             )
         """)
-        c0.execute("INSERT INTO product_asins SELECT * FROM _pa_tmp")
+        # List columns explicitly so future schema additions (like v8's
+        # not_listed_strikes) don't break this "force to v5 shape"
+        # scaffolding — _pa_tmp carries the live baseline's extra
+        # columns and `SELECT *` would produce a column-count mismatch.
+        c0.execute(
+            "INSERT INTO product_asins "
+            "(product_id, marketplace, asin, status, notes, "
+            " last_checked, created_at, updated_at) "
+            "SELECT product_id, marketplace, asin, status, notes, "
+            "       last_checked, created_at, updated_at FROM _pa_tmp"
+        )
         c0.execute("DROP TABLE _pa_tmp")
         c0.execute("DROP INDEX IF EXISTS idx_pa_asin")
         c0.commit()
@@ -500,13 +513,13 @@ class TestStatusMigrationV6:
         ).fetchone()
         assert idx is not None, "v6 migration must recreate idx_pa_asin"
 
-        # Migration records inserted. Reopen runs v6, v7, and v8 since
-        # all three records were cleared in Step 1, so MAX(version)
-        # advances to 8.
+        # Migration records inserted. Reopen runs v6, v7, v8 and v9
+        # since all four records were cleared in Step 1, so MAX(version)
+        # advances to the current SCHEMA_VERSION.
         ver = c2.execute(
             "SELECT MAX(version) AS v FROM schema_migrations"
         ).fetchone()
-        assert ver["v"] == 8
+        assert ver["v"] == 9
 
         # Tightened CHECK is in force: legacy values now rejected.
         with pytest.raises(sqlite3.IntegrityError):
@@ -610,7 +623,7 @@ class TestBrandModelKeyMigrationV7:
         init_schema(c0)
 
         c0.execute("PRAGMA foreign_keys = OFF")
-        c0.execute("DELETE FROM schema_migrations WHERE version IN (7, 8)")
+        c0.execute("DELETE FROM schema_migrations WHERE version >= 7")
         c0.execute("DROP TABLE products")
         c0.execute("""
             CREATE TABLE products (
@@ -754,7 +767,7 @@ class TestBrandModelKeyMigrationV7:
         init_schema(c0)
 
         c0.execute("PRAGMA foreign_keys = OFF")
-        c0.execute("DELETE FROM schema_migrations WHERE version IN (7, 8)")
+        c0.execute("DELETE FROM schema_migrations WHERE version >= 7")
         c0.execute("DROP TABLE products")
         c0.execute("""
             CREATE TABLE products (


### PR DESCRIPTION
## Summary

Fixes the silent-corruption bug in `ensure_keepa_data` post-fetch validation: a single transient Keepa response (rate-limit, network jitter, partial JSON) used to permanently flip an active ASIN to `not_listed` after one observation. This PR introduces a strike-counter guard — only **3 consecutive genuine empty responses** flip the row, while responses with a populated `PriceHistory.fetch_error` are treated as transient and leave status untouched.

Schema bumps to **v8** (in-place `ALTER TABLE`; legacy rows backfill to 0).

## Changes

### Behavior
- **Transient gate** — non-empty `fetch_error` (rate_limited, invalid_response, api_error, network, unexpected, max_retries_exhausted) skips strike accounting entirely; cached data stays valid.
- **Strike counter** — eligible empty responses (`fetch_error == ""`, no title, no csv) increment `product_asins.not_listed_strikes`. Flip happens only at `NOT_LISTED_STRIKE_THRESHOLD == 3`.
- **Success resets** — any fetch returning data calls `clear_not_listed_strikes`, clearing in-flight streaks.
- **Already-`not_listed` rows** — still increment the counter as an observational log; warning copy distinguishes "strike N/3 progression" (active rows) from "still observed as not_listed" (already-not_listed rows) so users don't see nonsensical "strike 4/3" text.

### Schema (v8)
- `product_asins.not_listed_strikes INTEGER NOT NULL DEFAULT 0`
- Helpers: `db.increment_not_listed_strikes()`, `db.clear_not_listed_strikes()`
- Constant: `db.NOT_LISTED_STRIKE_THRESHOLD = 3`

### API
- `_try_mark_not_listed` split into `_record_empty_observation` (returns `(strikes, flipped, was_active_on_entry)`) and `_record_successful_observation` (reset path).
- Three-branch post-fetch loop in `ensure_keepa_data`: transient / genuine empty / success.

## Files Changed

| File | Notes |
|---|---|
| `src/amz_scout/db.py` | Schema v8 + 2 helpers + threshold constant |
| `src/amz_scout/api.py` | Observation helper split; three-branch post-fetch flow |
| `tests/test_api.py` | +297 lines, 8 new tests in 3 classes |
| `tests/test_db.py` | Schema bump + migration-test scaffolding adapted (explicit column list, `WHERE version >= N`) |
| `docs/DEVELOPER.md` | v8 row, Transient-Failure Guard section, updated state diagram |
| `.claude/PRPs/{plans,reports,reviews}/…` | PRP plan, implementation report, local review |

## Testing

| Check | Result |
|---|---|
| `ruff check src/ tests/` | Pass |
| `pytest tests/test_api.py tests/test_db.py` | 154/154 |
| Full suite `pytest` | 312 passed, 8 skipped |
| Fresh DB schema v8 | `MAX(version) == 8`, column present |
| v7 → v8 migration on synthetic legacy DB | Pass; backfills to 0 |

New test classes:
- `TestEmptyObservationStrikes` (5) — strike state machine: unregistered no-op, first increment, threshold flip, success reset, already-`not_listed`
- `TestEnsureKeepaDataTransientVsPermanent` (2) — end-to-end: transient blip preserves status; genuine empty increments strike
- `TestAsinStatusRecovery` (1) — `not_listed → active` recovery restores `_resolve_asin` pass-through

## Related Issues

Closes #11

## Follow-ups (tracked here for visibility, NOT auto-closed by this PR)

- Use `keepa_products.availability_amazon == -1` to lower N for ASINs Keepa explicitly reports as unavailable
- Background `not_listed → active` auto-recovery job
- Cap on `not_listed_strikes` growth on permanently-delisted rows (currently uncapped observational log)

---

PRP artifacts: [plan](.claude/PRPs/plans/completed/fix-transient-failure-permanent-dead-listing.plan.md) · [report](.claude/PRPs/reports/fix-transient-failure-permanent-dead-listing-report.md) · [local review](.claude/PRPs/reviews/local-review-fix-transient-failure-permanent-dead-listing.md)