### PR TITLE
chore: drop temporary diag log from hotfix 96b1fa4

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -65,13 +65,6 @@ async def on_message(msg: cl.Message) -> None:
         final_text, updated_history = await run_chat_turn(history)
         cl.user_session.set("history", updated_history)
         success = True
-        # DIAG: log what we're about to send so we can distinguish
-        # "LLM returned empty" from "cl.Message.send() dropped the content"
-        logger.info(
-            "on_message → cl.Message.send (len=%d, preview=%r)",
-            len(final_text or ""),
-            (final_text or "")[:300],
-        )
     except Exception:
         # Keep stack + exception detail in server logs only — never echo the
         # raw exception to authenticated users since it can leak file paths,

--- a/webapp/llm.py
+++ b/webapp/llm.py
@@ -158,9 +158,10 @@ async def run_chat_turn(history: list[dict]) -> tuple[str, list[dict]]:
         if resp.stop_reason != "tool_use":
             # Final response — extract text and return
             final_text = "".join(block.text for block in resp.content if block.type == "text")
-            # DIAG: log block shape + text length so we can tell whether an
-            # "empty UI message" is caused by LLM returning zero text blocks
-            # (e.g. after web_search) vs a downstream send() issue.
+            # Log the response shape so an "empty UI message" downstream can
+            # be triaged at a glance: zero text blocks (LLM genuinely returned
+            # no prose, e.g. after server-tool only) vs non-zero text_len
+            # (problem is in the send/render path, not in generation).
             logger.info(
                 "Chat turn complete (iter=%d stop=%s blocks=%s text_len=%d)",
                 i + 1,


### PR DESCRIPTION
## Summary

Tidies up the short-lived diagnostic logging added during the Bug A / Bug B hotfix
(`96b1fa4 fix: thread container_id + offload anthropic calls to unblock ws loop`)
now that both bugs have been confirmed fixed via end-to-end testing.

## Changes

- **`webapp/app.py`**: remove `on_message → cl.Message.send (preview=%r)` DIAG log. The preview leaked the first 300 chars of every LLM reply into stdout — unnecessary for production and slightly PII-risky. Coverage for the original triage question ("did LLM return empty?") is preserved by the llm.py out-point log below.
- **`webapp/llm.py`**: keep the structured `Chat turn complete (iter=%d stop=%s blocks=%s text_len=%d)` log but rewrite its comment to drop the temporary `DIAG:` prefix and state the permanent observability value. This line proved load-bearing during the hotfix (it distinguishes "LLM returned zero text blocks" from "send/render path dropped the reply") and should stay.

Also preserved: `server-tool container_id=...` log (critical for future Anthropic protocol drift) and `turn_blocks=... WARNING` (existing cache-miss guard).

## Test plan

- [x] `pytest tests/test_webapp_smoke.py -q` → 36 passed
- [x] Manual smoke: end-to-end web_search + register_asin_from_url flow still works (confirmed in session preceding this PR; log line format unchanged)